### PR TITLE
Revoke API token when requesting a new one

### DIFF
--- a/packages/client/src/containers/apiTokenPage.tsx
+++ b/packages/client/src/containers/apiTokenPage.tsx
@@ -1,13 +1,25 @@
 import * as  React from "react";
-import { Layout, Card, Button, Row, Input, message, Modal } from 'antd';
+import { Layout, Card, Button, Row, Input, message, Modal, notification } from 'antd';
+import gql from 'graphql-tag';
+import { Mutation } from 'react-apollo';
+import { errorHandler } from "utils/errorHandler";
 
 type Props = {
+  revokeApiToken: Function;
 }
 
 type State = {
 }
 
-export default class ApiTokenPage extends React.Component<Props, State> {
+export const REVOKE_API_TOKEN = gql`
+  mutation revokeApiToken {
+    revokeApiToken {
+      id
+    }
+  }
+`;
+
+class ApiTokenPage extends React.Component<Props, State> {
   state = {
     modal: false
   }
@@ -32,12 +44,15 @@ export default class ApiTokenPage extends React.Component<Props, State> {
       title: 'Are you sure you want to request an API token?',
       content: 'Submitting a new request will revoke your existing token.',
       onOk: () => {
-        (window as any).location.href = this.requestApiTokenEndpoint;
+        const {revokeApiToken} = this.props;
+
+        revokeApiToken().then(() => {
+          (window as any).location.href = this.requestApiTokenEndpoint;
+        }, errorHandler)
       },
       onCancel() {},
-    });     
+    });
   }
-
 
   copyToken = () => {
     if (this.refToken && this.refToken.current) {
@@ -119,3 +134,13 @@ curl -X POST \\
     )
   }
 }
+
+export default () => (
+  <Mutation mutation={REVOKE_API_TOKEN}>
+    {
+      (revokeApiToken) => (
+        <ApiTokenPage revokeApiToken={revokeApiToken} />
+      )
+    }
+  </Mutation>
+)

--- a/packages/client/src/utils/errorHandler.tsx
+++ b/packages/client/src/utils/errorHandler.tsx
@@ -1,0 +1,31 @@
+import {get} from 'lodash';
+import {notification} from 'antd';
+
+export function errorHandler (e) {
+  // get the first error
+  let errorCode;
+  let message;
+  let description;
+  // from networkError
+  if (e.networkError) {
+    errorCode = get(e, 'networkError.result.errors.0.extensions.code');
+    description =  get(e, 'networkError.result.errors.0.message');
+  } else {
+    // from graphQLErrors
+    errorCode = get(e, 'graphQLErrors.0.extensions.code');
+    description =  get(e, 'graphQLErrors.0.message');
+  }
+
+  switch (errorCode) {
+    case 'EXCEED_QUOTA':
+      message = 'System Error';
+      description = description || 'The quota exceeded';
+      break;
+  };
+
+  notification.error({
+    message,
+    description,
+    placement: 'bottomRight'
+  });
+}

--- a/packages/graphql-server/src/app.ts
+++ b/packages/graphql-server/src/app.ts
@@ -96,6 +96,7 @@ const resolvers = {
     createUser: user.create,
     updateUser: user.update,
     deleteUser: user.destroy,
+    revokeApiToken: user.revokeApiToken,
     sendEmail: user.sendEmail,
     sendMultiEmail: user.sendMultiEmail,
     resetPassword: user.resetPassword,
@@ -268,6 +269,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
       let getImage: (name: string) => Promise<Item<ImageSpec>>;
 
       const kcAdminClient = createKcAdminClient();
+      const keycloakClientId = config.keycloakClientId;
       const {authorization = ''}: {authorization: string} = ctx.header;
       const useCache = ctx.headers['x-primehub-use-cache'];
       const isJobClient = ctx.headers['x-primehub-job'];
@@ -376,6 +378,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
         realm: config.keycloakRealmName,
         everyoneGroupId: config.keycloakEveryoneGroupId,
         kcAdminClient,
+        keycloakClientId,
         crdClient,
         getInstanceType: getInstanceType || memGetInstanceType(crdClient),
         getImage: getImage || memGetImage(crdClient),

--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -107,6 +107,7 @@ const ceResolvers = {
     createUser: user.create,
     updateUser: user.update,
     deleteUser: user.destroy,
+    revokeApiToken: user.revokeApiToken,
     sendEmail: user.sendEmail,
     sendMultiEmail: user.sendMultiEmail,
     resetPassword: user.resetPassword,
@@ -350,6 +351,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
       let getImage: (name: string) => Promise<Item<ImageSpec>>;
 
       const kcAdminClient = createKcAdminClient();
+      const keycloakClientId = config.keycloakClientId;
       const {authorization = ''}: {authorization: string} = ctx.header;
       const useCache = ctx.headers['x-primehub-use-cache'];
       const isJobClient = ctx.headers['x-primehub-job'];
@@ -458,6 +460,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
         realm: config.keycloakRealmName,
         everyoneGroupId: config.keycloakEveryoneGroupId,
         kcAdminClient,
+        keycloakClientId,
         crdClient,
         getInstanceType: getInstanceType || memGetInstanceType(crdClient),
         getImage: getImage || memGetImage(crdClient),

--- a/packages/graphql-server/src/ee/middlewares/auth.ts
+++ b/packages/graphql-server/src/ee/middlewares/auth.ts
@@ -22,6 +22,7 @@ export const permissions = shield({
   },
   Mutation: {
     '*': isAdmin,
+    'revokeApiToken': or(isAdmin, isUser),
     'createPhJob': or(isAdmin, isUser),
     'rerunPhJob': or(isAdmin, isUser),
     'cancelPhJob': or(isAdmin, isUser),

--- a/packages/graphql-server/src/graphql/index.graphql
+++ b/packages/graphql-server/src/graphql/index.graphql
@@ -186,6 +186,7 @@ type Mutation {
   sendEmail(id: String, resetActions: [String], expiresIn: Int): UserActionResponse
   sendMultiEmail(in: [String], resetActions: [String], expiresIn: Int): UserMultiEmailResponse
   resetPassword(id: String, password: String, temporary: Boolean): UserActionResponse
+  revokeApiToken: UserActionResponse
 
   """Group"""
   createGroup(data: GroupCreateInput!): Group!

--- a/packages/graphql-server/src/middlewares/auth.ts
+++ b/packages/graphql-server/src/middlewares/auth.ts
@@ -13,6 +13,7 @@ export const permissions = shield({
   },
   Mutation: {
     '*': isAdmin,
+    'revokeApiToken': or(isAdmin, isUser),
   },
 }, {
   allowExternalErrors: true

--- a/packages/graphql-server/src/resolvers/interface.ts
+++ b/packages/graphql-server/src/resolvers/interface.ts
@@ -20,6 +20,7 @@ export interface Context {
   realm: string;
   everyoneGroupId: string;
   kcAdminClient: KcAdminClient;
+  keycloakClientId: string;
   crdClient: CrdClient;
   getInstanceType: (name: string) => Promise<Item<InstanceTypeSpec>>;
   getImage: (name: string) => Promise<Item<ImageSpec>>;

--- a/packages/graphql-server/src/resolvers/user.ts
+++ b/packages/graphql-server/src/resolvers/user.ts
@@ -670,6 +670,36 @@ export const resetPassword = async (root, args, context: Context) => {
   return {id};
 };
 
+export const revokeApiToken = async (root, args, context: Context) => {
+  const id = context.userId;
+
+  try {
+    await context.kcAdminClient.users.revokeConsent({
+      id,
+      clientId: context.keycloakClientId
+    });
+  } catch (e) {
+    if (e.response && e.response.status === 404) {
+      // no offline token
+    } else {
+      logger.error({
+        type: 'REVOKE_API_TOKEN_FAILED',
+        id,
+        clientId: context.keycloakClientId,
+        error: e
+      });
+      throw new ApolloError('Cannot revoke API token', 'USER_REVOKE_FAILED');
+    }
+  }
+
+  logger.info({
+    component: logger.components.user,
+    type: 'REVOKE_API_TOKEN',
+    targetUserId: id
+  });
+  return {id};
+};
+
 /**
  * Type
  */


### PR DESCRIPTION
https://app.clubhouse.io/infuseai/story/10193/api-with-auth-revoke-the-token-after-new-token-is-created

1. Create a graphql mutation to revoke API token
2. In the UI, revoke the token before requesting the new token.

Signed-off-by: popcorny <celu@infuseai.io>