### PR TITLE
Fix the object prefix

### DIFF
--- a/packages/graphql-server/src/ee/controllers/jobLogCtrl.ts
+++ b/packages/graphql-server/src/ee/controllers/jobLogCtrl.ts
@@ -66,7 +66,7 @@ export class JobLogCtrl {
       if (tailLines) {
         tail = parseInt(tailLines, 10);
       }
-      const prefix = `/logs/phjob/${jobId}`;
+      const prefix = `logs/phjob/${jobId}`;
       stream = await this.persistLog.getStream(prefix, {tailLines: tail});
     } else {
       stream = this.getStream(namespace, podName, {follow, tailLines});


### PR DESCRIPTION
Signed-off-by: popcorny <celu@infuseai.io>

https://app.clubhouse.io/infuseai/story/8831/primehub-console-allows-to-get-log-from-primehub-store

The prefix is not working under gateway to gcs