### PR TITLE
Group-context-aware components support group prop

### DIFF
--- a/packages/client/src/containers/list.tsx
+++ b/packages/client/src/containers/list.tsx
@@ -8,6 +8,7 @@ import {withRouter} from 'react-router';
 import {RouteComponentProps} from 'react-router-dom';
 import withPath, { PathComponentProps } from 'ee/components/job/withPath';
 import {appPrefix} from 'utils/env';
+import {withGroupContext, GroupContextComponentProps} from 'context/group';
 
 export const GroupFragment = gql`
   fragment GroupInfo on Group {
@@ -34,7 +35,8 @@ type Props = {
   getMyGroups: any;
   Com: any;
 } & RouteComponentProps
-  & PathComponentProps;
+  & PathComponentProps
+  & GroupContextComponentProps;
 
 class ListContainer extends React.Component<Props> {
   render() {
@@ -60,6 +62,7 @@ class ListContainer extends React.Component<Props> {
 export default compose(
   withRouter,
   withPath,
+  withGroupContext,
   graphql(GET_MY_GROUPS, {
     name: 'getMyGroups',
     options: (props: Props) => ({

--- a/packages/client/src/containers/list.tsx
+++ b/packages/client/src/containers/list.tsx
@@ -8,7 +8,7 @@ import {withRouter} from 'react-router';
 import {RouteComponentProps} from 'react-router-dom';
 import withPath, { PathComponentProps } from 'ee/components/job/withPath';
 import {appPrefix} from 'utils/env';
-import {withGroupContext, GroupContextComponentProps} from 'context/group';
+import {withGroupContext, GroupContextComponentProps, GroupContext} from 'context/group';
 
 export const GroupFragment = gql`
   fragment GroupInfo on Group {
@@ -41,6 +41,7 @@ type Props = {
 class ListContainer extends React.Component<Props> {
   render() {
     const {
+      groupContext,
       getMyGroups,
       Com,
     } = this.props;
@@ -54,6 +55,7 @@ class ListContainer extends React.Component<Props> {
     return (
       <Com
         groups={groups}
+        groupContext={groupContext}
       />
     );
   }

--- a/packages/client/src/context/group.tsx
+++ b/packages/client/src/context/group.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export interface GroupContextValue {
+  id: string;
+  name: string;
+  displayName: string;
+}
+
+
+export const GroupContext = React.createContext<GroupContextValue>(undefined);
+
+export type GroupContextComponentProps = {
+  groupContext: GroupContextValue
+}
+
+export  function withGroupContext(Com) {
+  return class ComWithGroupContext extends React.Component<any> {
+    render() {
+      return <GroupContext.Consumer>
+        {(groupContext) => <Com {...this.props} groupContext={groupContext} />}
+      </GroupContext.Consumer>
+    }
+  }
+}

--- a/packages/client/src/ee/components/job/createForm.tsx
+++ b/packages/client/src/ee/components/job/createForm.tsx
@@ -8,6 +8,7 @@ import Message from 'components/share/message';
 const { Option } = Select;
 
 type Props = FormComponentProps & {
+  groupContext?: any;
   groups: Array<Record<string, any>>;
   onSelectGroup: Function;
   selectedGroup: string;
@@ -185,6 +186,7 @@ class CreateForm extends React.Component<Props, State> {
 
   render() {
     const {
+      groupContext,
       groups,
       onSelectGroup,
       instanceTypes,
@@ -225,7 +227,7 @@ class CreateForm extends React.Component<Props, State> {
       <span>The group <b>{groupName}</b> was deleted.</span>
     )
 
-    const invalidInitialInstanceType = !invalidInitialGroup && 
+    const invalidInitialInstanceType = !invalidInitialGroup &&
       instanceTypeId && !form.getFieldValue('instanceType') &&
       !instanceTypes.find(it => it.id === instanceTypeId);
 
@@ -252,7 +254,7 @@ class CreateForm extends React.Component<Props, State> {
               <Divider />
               {
                 groups.length ? (
-                  <Form.Item label={groupLabel}>
+                  <Form.Item label={groupLabel} style={ groupContext ? { display: 'none' } : {} }>
                     {form.getFieldDecorator('groupId', {
                       initialValue: invalidInitialGroup ? '' : groupId,
                       rules: [{ required: true, message: 'Please select a group!' }],
@@ -333,7 +335,7 @@ class CreateForm extends React.Component<Props, State> {
                   )
                 )}
               </Form.Item>
-              
+
             </Card>
           </Col>
           <Col xs={24} sm={16} lg={16}>

--- a/packages/client/src/ee/components/job/list.tsx
+++ b/packages/client/src/ee/components/job/list.tsx
@@ -14,6 +14,7 @@ import {appPrefix} from 'utils/env';
 import PageTitle from 'components/pageTitle';
 import PageBody from 'components/pageBody';
 import InfuseButton from 'components/infuseButton';
+import { GroupContextComponentProps } from 'context/group';
 
 const {confirm} = Modal;
 
@@ -34,7 +35,7 @@ const renderJobName = (text, record) => (
         prevPathname: location.pathname,
         prevSearch: location.search,
       },
-      pathname: `${appPrefix}job/${record.id}`
+      pathname: `job/${record.id}`
     }} >
       {text}
     </Link>
@@ -42,7 +43,7 @@ const renderJobName = (text, record) => (
 );
 
 const renderSchedule = text => text ? (
-  <Link to={`${appPrefix}schedule/${text}`}>
+  <Link to={`schedule/${text}`}>
     {text}
   </Link>
 ) : '-'
@@ -70,7 +71,7 @@ const getCreateTimeAndFinishTime = (startTime, finishTime, phase: Phase) => {
         startTime: renderTimeIfValid(startTime),
         finishTime: '-'
       };
-  
+
     default:
       return {
         startTime: renderTimeIfValid(startTime),
@@ -130,7 +131,7 @@ type JobsConnection = {
   }>
 }
 
-type Props = RouteComponentProps & {
+type Props = RouteComponentProps & GroupContextComponentProps & {
   groups: Array<Group>;
   jobsLoading: boolean;
   jobsError: any;
@@ -188,15 +189,18 @@ class JobList extends React.Component<Props> {
 
   createPhJob = () => {
     const {history} = this.props;
-    history.push(`${appPrefix}job/create`);
+    history.push(`job/create`);
   }
 
   refresh = () => {
-    const {jobsVariables, jobsRefetch} = this.props;
+    const {groupContext, jobsVariables, jobsRefetch} = this.props;
     const newVariables = {
       ...jobsVariables,
       page: 1,
     };
+    if (groupContext && newVariables.where) {
+      newVariables.where.groupId_in = undefined;
+    }
     jobsRefetch(newVariables);
   }
 
@@ -207,12 +211,12 @@ class JobList extends React.Component<Props> {
     selectedGroups: Array<string>;
     submittedByMe: boolean;
   }) => {
-    const {jobsVariables, jobsRefetch} = this.props;
+    const {groupContext, jobsVariables, jobsRefetch} = this.props;
     const newVariables = {
       ...jobsVariables,
       where: {
         ...jobsVariables.where,
-        groupId_in: selectedGroups,
+        groupId_in: groupContext ? undefined : selectedGroups,
         mine: submittedByMe,
       }
     };
@@ -233,21 +237,21 @@ class JobList extends React.Component<Props> {
   }
 
   cloneJob = (record) => {
-    const {history} = this.props;
-    const data = {
+    const {groupContext, history} = this.props;
+    let data: any = {
       displayName: record.displayName,
-      groupId: record.groupId,
-      groupName: record.groupName,
+      groupId: !groupContext ? record.groupId : groupContext.id,
+      groupName: !groupContext ? record.groupName : groupContext.name,
       instanceTypeId: get(record, 'instanceType.id'),
       instanceTypeName: get(record, 'instanceType.displayName') || get(record, 'instanceType.name'),
       image: record.image,
       command: record.command,
     }
-    history.push(`${appPrefix}job/create?defaultValue=${JSON.stringify(data)}`)
+    history.push(`job/create?defaultValue=${JSON.stringify(data)}`)
   }
 
   render() {
-    const {groups, jobsConnection, jobsLoading, jobsVariables, cancelPhJobResult, rerunPhJobResult} = this.props;
+    const {groupContext, groups, jobsConnection, jobsLoading, jobsVariables, cancelPhJobResult, rerunPhJobResult} = this.props;
     const {currentId} = this.state;
     const renderAction = (phase: Phase, record) => {
       const action = getActionByPhase(phase);
@@ -330,6 +334,7 @@ class JobList extends React.Component<Props> {
             </div>
           </div>
           <Filter
+            groupContext={groupContext}
             groups={groups}
             selectedGroups={get(jobsVariables, 'where.groupId_in', [])}
             submittedByMe={get(jobsVariables, 'where.mine', false)}

--- a/packages/client/src/ee/components/modelDeployment/createForm.tsx
+++ b/packages/client/src/ee/components/modelDeployment/createForm.tsx
@@ -9,6 +9,7 @@ import ImagePullSecret from 'components/share/ImagePullSecret';
 const { Option } = Select;
 
 type Props = FormComponentProps & {
+  groupContext: any;
   groups: Array<Record<string, any>>;
   onSelectGroup?: Function;
   selectedGroup: string;
@@ -142,6 +143,7 @@ class DeploymentCreateForm extends React.Component<Props, State> {
 
   render() {
     const {
+      groupContext,
       groups,
       onSelectGroup,
       instanceTypes,
@@ -188,7 +190,7 @@ class DeploymentCreateForm extends React.Component<Props, State> {
           <Col xs={24} sm={16} lg={16}>
               {
                 groups.length ? (
-                  <Form.Item label={groupLabel}>
+                  <Form.Item label={groupLabel} style={ groupContext ? { display: 'none' } : {} }>
                     {form.getFieldDecorator('groupId', {
                       initialValue: invalidInitialGroup ? '' : groupId,
                       rules: [{ required: true, message: 'Please select a group!' }],

--- a/packages/client/src/ee/components/schedule/list.tsx
+++ b/packages/client/src/ee/components/schedule/list.tsx
@@ -10,10 +10,10 @@ import {Group} from '../shared/groupFilter';
 import Pagination from 'components/share/pagination';
 import ScheduleBreadCrumb from './breadcrumb';
 import {renderRecurrence} from './recurrence';
-import {appPrefix} from 'utils/env';
 import PageTitle from 'components/pageTitle';
 import PageBody from 'components/pageBody';
 import InfuseButton from 'components/infuseButton';
+import { GroupContextComponentProps } from 'context/group';
 
 const {confirm} = Modal;
 
@@ -60,7 +60,7 @@ type JobsConnection = {
   }>
 }
 
-type Props = RouteComponentProps & {
+type Props = RouteComponentProps & GroupContextComponentProps & {
   groups: Array<Group>;
   schedulesLoading: boolean;
   schedulesError: any;
@@ -103,7 +103,7 @@ class ScheduleList extends React.Component<Props> {
 
   editJob = (id: string) => {
     const {history, location} = this.props;
-    history.push(`${appPrefix}schedule/${id}`, {
+    history.push(`schedule/${id}`, {
       prevPathname: location.pathname,
       prevSearch: location.search,
     });
@@ -111,15 +111,18 @@ class ScheduleList extends React.Component<Props> {
 
   scheduleJob = () => {
     const {history} = this.props;
-    history.push(`${appPrefix}schedule/create`);
+    history.push(`schedule/create`);
   }
 
   refresh = () => {
-    const {schedulesVariables, schedulesRefetch} = this.props;
+    const {groupContext, schedulesVariables, schedulesRefetch} = this.props;
     const newVariables = {
       ...schedulesVariables,
       page: 1,
     };
+    if (groupContext && newVariables.where) {
+      newVariables.where.groupId_in = undefined;
+    }
     schedulesRefetch(newVariables);
   }
 
@@ -130,15 +133,16 @@ class ScheduleList extends React.Component<Props> {
     selectedGroups: Array<string>;
     submittedByMe: boolean;
   }) => {
-    const {schedulesVariables, schedulesRefetch} = this.props;
+    const {groupContext, schedulesVariables, schedulesRefetch} = this.props;
     const newVariables = {
       ...schedulesVariables,
       where: {
         ...schedulesVariables.where,
-        groupId_in: selectedGroups,
+        groupId_in: groupContext ? undefined : selectedGroups,
         mine: submittedByMe,
       }
     };
+
     schedulesRefetch(newVariables);
   }
 
@@ -156,7 +160,7 @@ class ScheduleList extends React.Component<Props> {
 
 
   render() {
-    const {groups, schedulesConnection, schedulesLoading, schedulesVariables, deletePhScheduleResult, runPhScheduleResult} = this.props;
+    const {groupContext, groups, schedulesConnection, schedulesLoading, schedulesVariables, deletePhScheduleResult, runPhScheduleResult} = this.props;
     const renderAction = (id: string, record) => {
       return (
         <Button.Group>
@@ -214,6 +218,7 @@ class ScheduleList extends React.Component<Props> {
             </div>
           </div>
           <Filter
+            groupContext={groupContext}
             groups={groups}
             selectedGroups={get(schedulesVariables, 'where.groupId_in', [])}
             submittedByMe={get(schedulesVariables, 'where.mine', false)}

--- a/packages/client/src/ee/components/shared/filter.tsx
+++ b/packages/client/src/ee/components/shared/filter.tsx
@@ -6,10 +6,11 @@ import {FilterRow, FilterPlugins, ButtonCol} from 'root/cms-toolbar/filter';
 import {Label} from 'root/cms-toolbar/share';
 
 type Props = {
+  groupContext?: any;
   groups: Group[];
   selectedGroups: Array<string>;
   submittedByMe: boolean;
-  labelSubmittedByMe: string;
+  labelSubmittedByMe?: string;
   onChange: ({
     selectedGroups,
     submittedByMe
@@ -41,20 +42,31 @@ export default class Filter extends React.Component<Props> {
   }
 
   render() {
-    const {groups, selectedGroups, submittedByMe, labelSubmittedByMe} = this.props;
+    const {groupContext, groups, selectedGroups, submittedByMe, labelSubmittedByMe} = this.props;
+
+    const filterComps = []
+    if( !groupContext ) {
+      // Not in group context
+      filterComps.push(<Col style={{flex: 1}}>
+        <FilterPlugins style={{marginRight: 0}}>
+          <Label>Group</Label>
+          <GroupFilter
+            groups={groups}
+            selectedGroups={selectedGroups}
+            onChange={this.handleSelectedGroupsChange}
+          />
+        </FilterPlugins>
+      </Col>);
+      filterComps.push(
+        <div style={{borderLeft: '1px solid #d9d9d9', margin: '0px 8px 2px', height: 28}} />
+      )
+    } else {
+      filterComps.push(<Col style={{flex: 1}} />);
+    }
+
     return (
       <FilterRow type="flex" justify="space-between" align="bottom" style={{marginBottom: 16, marginTop: 16}}>
-        <Col style={{flex: 1}}>
-          <FilterPlugins style={{marginRight: 0}}>
-            <Label>Group</Label>
-            <GroupFilter
-              groups={groups}
-              selectedGroups={selectedGroups}
-              onChange={this.handleSelectedGroupsChange}
-            />
-          </FilterPlugins>
-        </Col>
-        <div style={{borderLeft: '1px solid #d9d9d9', margin: '0px 8px 2px', height: 28}} />
+        { ...filterComps }
         <ButtonCol>
           <Checkbox
             style={{

--- a/packages/client/src/ee/containers/deploymentCreatePage.tsx
+++ b/packages/client/src/ee/containers/deploymentCreatePage.tsx
@@ -85,10 +85,10 @@ class DeploymentCreatePage extends React.Component<Props, State> {
     const {selectedGroup} = this.state;
     const {groupContext, getGroups, createPhDeploymentResult, history} = this.props;
     const everyoneGroupId = (window as any).EVERYONE_GROUP_ID;
-    const allGroups = get(getGroups, 'me.groups', [])
-      .filter(group => group.enabledDeployment || group.id === everyoneGroupId)
+    const allGroups = get(getGroups, 'me.groups', []).filter(group => group.enabledDeployment || group.id === everyoneGroupId);
+    const groups = allGroups
+      .filter(group => group.id !== everyoneGroupId)
       .filter(group => !groupContext || groupContext.id === group.id );
-    const groups = allGroups.filter(group => group.id !== everyoneGroupId);
     const everyoneGroup = allGroups.find(group => group.id === everyoneGroupId);
     const group = groups
       .find(group => group.id === selectedGroup);

--- a/packages/client/src/ee/containers/deploymentCreatePage.tsx
+++ b/packages/client/src/ee/containers/deploymentCreatePage.tsx
@@ -13,6 +13,7 @@ import DeploymentBreadcrumb from 'ee/components/modelDeployment/breadcrumb';
 import {GroupFragment} from 'containers/list';
 import {appPrefix} from 'utils/env';
 import PageTitle from 'components/pageTitle';
+import { GroupContextComponentProps, withGroupContext } from 'context/group';
 
 export const GET_MY_GROUPS = gql`
   query me {
@@ -53,8 +54,8 @@ export const sortItems = (items) => {
   return copiedItems;
 }
 
-type Props = RouteComponentProps & {
-  getGroups: any; 
+type Props = RouteComponentProps & GroupContextComponentProps & {
+  getGroups: any;
   createPhDeployment: any;
   createPhDeploymentResult: any;
 }
@@ -82,9 +83,11 @@ class DeploymentCreatePage extends React.Component<Props, State> {
 
   render() {
     const {selectedGroup} = this.state;
-    const {getGroups, createPhDeploymentResult, history} = this.props;
+    const {groupContext, getGroups, createPhDeploymentResult, history} = this.props;
     const everyoneGroupId = (window as any).EVERYONE_GROUP_ID;
-    const allGroups = get(getGroups, 'me.groups', []).filter(group => group.enabledDeployment || group.id === everyoneGroupId);
+    const allGroups = get(getGroups, 'me.groups', [])
+      .filter(group => group.enabledDeployment || group.id === everyoneGroupId)
+      .filter(group => !groupContext || groupContext.id === group.id );
     const groups = allGroups.filter(group => group.id !== everyoneGroupId);
     const everyoneGroup = allGroups.find(group => group.id === everyoneGroupId);
     const group = groups
@@ -108,6 +111,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
         />
         <div style={{margin: '16px 64px'}}>
           <DeploymentCreateForm
+            groupContext={groupContext}
             onSelectGroup={this.onChangeGroup}
             selectedGroup={selectedGroup}
             groups={sortItems(groups)}
@@ -124,6 +128,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
 
 export default compose(
   withRouter,
+  withGroupContext,
   graphql(GET_MY_GROUPS, {
     name: 'getGroups'
   }),

--- a/packages/client/src/ee/containers/jobCreatePage.tsx
+++ b/packages/client/src/ee/containers/jobCreatePage.tsx
@@ -13,6 +13,7 @@ import JobBreadcrumb from '../components/job/breadcrumb';
 import {GroupFragment} from 'containers/list';
 import {appPrefix} from 'utils/env';
 import PageTitle from 'components/pageTitle';
+import { withGroupContext, GroupContextComponentProps } from 'context/group';
 
 export const GET_MY_GROUPS = gql`
   query me {
@@ -53,8 +54,8 @@ const sortItems = (items) => {
   return copiedItems;
 }
 
-type Props = RouteComponentProps & {
-  getGroups: any; 
+type Props = RouteComponentProps & GroupContextComponentProps & {
+  getGroups: any;
   createPhJob: any;
   createPhJobResult: any;
   defaultValue?: object;
@@ -86,10 +87,12 @@ class JobCreatePage extends React.Component<Props, State> {
 
   render() {
     const {selectedGroup} = this.state;
-    const {getGroups, createPhJobResult, defaultValue} = this.props;
+    const {groupContext, getGroups, createPhJobResult, defaultValue} = this.props;
     const everyoneGroupId = (window as any).EVERYONE_GROUP_ID;
     const allGroups = get(getGroups, 'me.groups', []);
-    const groups = allGroups.filter(group => group.id !== everyoneGroupId);
+    const groups = allGroups
+      .filter(group => group.id !== everyoneGroupId)
+      .filter(group => !groupContext || groupContext.id === group.id );
     const everyoneGroup = allGroups.find(group => group.id === everyoneGroupId);
     const group = groups
       .find(group => group.id === selectedGroup);
@@ -132,6 +135,7 @@ class JobCreatePage extends React.Component<Props, State> {
             </Row>
           ) : (
             <JobCreateForm
+              groupContext={groupContext}
               initialValue={defaultValue}
               onSelectGroup={this.onChangeGroup}
               selectedGroup={selectedGroup}
@@ -142,7 +146,7 @@ class JobCreatePage extends React.Component<Props, State> {
               loading={createPhJobResult.loading}
             />
           )}
-          
+
         </div>
       </React.Fragment>
     );
@@ -151,6 +155,7 @@ class JobCreatePage extends React.Component<Props, State> {
 
 export default compose(
   withRouter,
+  withGroupContext,
   graphql(GET_MY_GROUPS, {
     name: 'getGroups'
   }),

--- a/packages/client/src/ee/containers/modelDeploymentList.tsx
+++ b/packages/client/src/ee/containers/modelDeploymentList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Row, Col, Button, Skeleton, Input, message, Spin, Divider} from 'antd';
+import {Row, Col, Button, Skeleton, Input, message, Spin, Divider, Alert} from 'antd';
 import gql from 'graphql-tag';
 import {graphql} from 'react-apollo';
 import {compose} from 'recompose';
@@ -44,6 +44,12 @@ export const GET_PH_DEPLOYMENT_CONNECTION = gql`
 `;
 
 type Props = {
+  groups: Array<{
+    id: string;
+    name: string;
+    displayName: string;
+    enabledDeployment: boolean;
+  }>;
   getPhDeploymentConnection: {
     error?: any;
     loading: boolean;
@@ -153,6 +159,81 @@ class DeploymentListContainer extends React.Component<Props, State> {
       return <Skeleton />
     }
 
+    let showContent = true;
+
+    let pageBody = <>
+      <div style={{textAlign: 'right', margin: '16px 0px 5px'}}>
+        <Search
+          placeholder="Search deploy name"
+          style={{width: 295, margin: 'auto 16px'}}
+          onSearch={this.searchHandler}
+        />
+        <InfuseButton
+          icon="plus"
+          type="primary"
+          onClick={() => history.push(`${appPrefix}model-deployment/create`)}
+          style={{marginRight: 16, width: 'auto'}}
+        >
+          Create Deployment
+        </InfuseButton>
+        <InfuseButton onClick={() => refetch()}>Refresh</InfuseButton>
+      </div>
+      <Filter
+        groupContext={groupContext}
+        labelSubmittedByMe={"Deployed By Me"}
+        groups={groups}
+        selectedGroups={get(variables, 'where.groupId_in', [])}
+        submittedByMe={get(variables, 'where.mine', false)}
+        onChange={this.changeFilter}
+      />
+    </>;
+
+    if ( groupContext ) {
+      const group = groups.find(group => group.id === groupContext.id);
+      if ( !group ) {
+        pageBody = <Alert
+          message="Group not found"
+          description={`Group ${groupContext.name} is not found or not authorized.`}
+          type="error"
+          showIcon/>;
+          showContent = false;
+      } else if ( group.enabledDeployment == false ) {
+        pageBody = <Alert
+          message="Feature not available"
+          description={'Model Deployment is not enabled for this group. Please tell the adminstrator to enable it.'}
+          type="warning"
+          showIcon/>;
+        showContent = false;
+      }
+    }
+
+    const content = <div style={{margin: '16px 64px'}}>
+        <Spin spinning={loading}>
+          <Row gutter={36} type="flex">
+            {phDeploymentsConnection.edges.map(edge => {
+              return (
+                <Col span={6} key={edge.cursor} style={{marginBottom: 36}}>
+                  <DeploymentCard
+                    deployment={edge.node}
+                    copyClipBoard={this.copyClipBoard}
+                  />
+                </Col>
+              );
+            })}
+          </Row>
+        </Spin>
+        <Input
+          ref={this.textArea}
+          style={{position: 'absolute', left: '-1000px', top: '-1000px'}}
+        />
+        <Pagination
+          hasNextPage={phDeploymentsConnection.pageInfo.hasNextPage}
+          hasPreviousPage={phDeploymentsConnection.pageInfo.hasPreviousPage}
+          nextPage={this.nextPage}
+          previousPage={this.previousPage}
+        />
+      </div>
+
     return (
       <>
         <PageTitle
@@ -160,58 +241,8 @@ class DeploymentListContainer extends React.Component<Props, State> {
           title={"Model Deployments"}
           style={{paddingLeft: 64}}
         />
-          <PageBody>
-            <div style={{textAlign: 'right', margin: '16px 0px 5px'}}>
-              <Search
-                placeholder="Search deploy name"
-                style={{width: 295, margin: 'auto 16px'}}
-                onSearch={this.searchHandler}
-              />
-              <InfuseButton
-                icon="plus"
-                type="primary"
-                onClick={() => history.push(`${appPrefix}model-deployment/create`)}
-                style={{marginRight: 16, width: 'auto'}}
-              >
-                Create Deployment
-              </InfuseButton>
-              <InfuseButton onClick={() => refetch()}>Refresh</InfuseButton>
-            </div>
-            <Filter
-              groupContext={groupContext}
-              labelSubmittedByMe={"Deployed By Me"}
-              groups={groups}
-              selectedGroups={get(variables, 'where.groupId_in', [])}
-              submittedByMe={get(variables, 'where.mine', false)}
-              onChange={this.changeFilter}
-            />
-          </PageBody>
-          <div style={{margin: '16px 64px'}}>
-          <Spin spinning={loading}>
-            <Row gutter={36} type="flex">
-              {phDeploymentsConnection.edges.map(edge => {
-                return (
-                  <Col span={6} key={edge.cursor} style={{marginBottom: 36}}>
-                    <DeploymentCard
-                      deployment={edge.node}
-                      copyClipBoard={this.copyClipBoard}
-                    />
-                  </Col>
-                );
-              })}
-            </Row>
-          </Spin>
-          <Input
-            ref={this.textArea}
-            style={{position: 'absolute', left: '-1000px', top: '-1000px'}}
-          />
-          <Pagination
-            hasNextPage={phDeploymentsConnection.pageInfo.hasNextPage}
-            hasPreviousPage={phDeploymentsConnection.pageInfo.hasPreviousPage}
-            nextPage={this.nextPage}
-            previousPage={this.previousPage}
-          />
-        </div>
+        <PageBody>{pageBody}</PageBody>
+        { showContent ? content : <></> }
       </>
     );
   }

--- a/packages/client/src/ee/containers/modelDeploymentList.tsx
+++ b/packages/client/src/ee/containers/modelDeploymentList.tsx
@@ -200,7 +200,7 @@ class DeploymentListContainer extends React.Component<Props, State> {
       } else if ( group.enabledDeployment == false ) {
         pageBody = <Alert
           message="Feature not available"
-          description={'Model Deployment is not enabled for this group. Please tell the adminstrator to enable it.'}
+          description="Model Deployment is not enabled for this group. Please contact your administrator to enable it."
           type="warning"
           showIcon/>;
         showContent = false;

--- a/packages/client/src/ee/containers/scheduleCreatePage.tsx
+++ b/packages/client/src/ee/containers/scheduleCreatePage.tsx
@@ -13,6 +13,7 @@ import ScheduleCreateForm from 'ee/components/job/createForm';
 import {GroupFragment} from 'containers/list';
 import {appPrefix} from 'utils/env';
 import PageTitle from 'components/pageTitle';
+import { withGroupContext, GroupContextComponentProps } from 'context/group';
 
 export const GET_MY_GROUPS = gql`
   query me {
@@ -64,8 +65,8 @@ export const sortItems = (items) => {
   return copiedItems;
 }
 
-type Props = RouteComponentProps & {
-  getGroups: any; 
+type Props = RouteComponentProps & GroupContextComponentProps & {
+  getGroups: any;
   createPhSchedule: any;
   createPhScheduleResult: any;
   getTimezone: Function;
@@ -94,13 +95,16 @@ class ScheduleCreatePage extends React.Component<Props, State> {
 
   render() {
     const {selectedGroup} = this.state;
-    const {getGroups, getTimezone, createPhScheduleResult, history} = this.props;
+    const {groupContext, getGroups, getTimezone, createPhScheduleResult, history} = this.props;
     const everyoneGroupId = (window as any).EVERYONE_GROUP_ID;
     const allGroups = get(getGroups, 'me.groups', []);
-    const groups = allGroups.filter(group => group.id !== everyoneGroupId);
+    const groups = allGroups
+      .filter(group => group.id !== everyoneGroupId)
+      .filter(group => !groupContext || groupContext.id === group.id );
     const everyoneGroup = allGroups.find(group => group.id === everyoneGroupId);
     const group = groups
       .find(group => group.id === selectedGroup);
+
     const instanceTypes = unionBy(
       get(group, 'instanceTypes', []),
       get(everyoneGroup, 'instanceTypes', []),
@@ -111,6 +115,7 @@ class ScheduleCreatePage extends React.Component<Props, State> {
       get(everyoneGroup, 'images', []),
       'id'
     );
+
     return (
       <React.Fragment>
         <PageTitle
@@ -119,6 +124,7 @@ class ScheduleCreatePage extends React.Component<Props, State> {
         />
         <div style={{margin: 16}}>
           <ScheduleCreateForm
+            groupContext={groupContext}
             onSelectGroup={this.onChangeGroup}
             selectedGroup={selectedGroup}
             groups={sortItems(groups)}
@@ -137,6 +143,7 @@ class ScheduleCreatePage extends React.Component<Props, State> {
 
 export default compose(
   withRouter,
+  withGroupContext,
   graphql(GET_MY_GROUPS, {
     name: 'getGroups'
   }),

--- a/packages/client/src/ee/containers/scheduleDetail.tsx
+++ b/packages/client/src/ee/containers/scheduleDetail.tsx
@@ -14,16 +14,17 @@ import {GET_MY_GROUPS, GET_TIMEZONE, sortItems} from './scheduleCreatePage';
 import {get, unionBy, isEqual} from 'lodash';
 import {appPrefix} from '../../utils/env';
 import PageTitle from '../../components/pageTitle';
+import { withGroupContext, GroupContextComponentProps } from 'context/group';
 
 type Props = {
-  getGroups: any; 
+  getGroups: any;
   getPhSchedule: any;
   updatePhSchedule: Function;
   updatePhScheduleResult: any;
   getTimezone: Function;
 } & RouteComponentProps<{
   scheduleId: string;
-}>;
+}> & GroupContextComponentProps;
 
 export const GET_PH_SCHEDULE = gql`
   query phSchedule($where: PhScheduleWhereUniqueInput!) {
@@ -105,7 +106,7 @@ class ScheduleDetailContainer extends React.Component<Props> {
   }
 
   render() {
-    const {getPhSchedule, getTimezone, getGroups, history, updatePhScheduleResult} = this.props;
+    const {groupContext, getPhSchedule, getTimezone, getGroups, history, updatePhScheduleResult} = this.props;
     if (getPhSchedule.loading) return null;
     if (getPhSchedule.error) {
       return getMessage(getPhSchedule.error)
@@ -135,6 +136,7 @@ class ScheduleDetailContainer extends React.Component<Props> {
         />
         <div style={{margin: 16}}>
           <ScheduleUpdateForm
+            groupContext={groupContext}
             onSelectGroup={this.onChangeGroup}
             selectedGroup={selectedGroup}
             groups={sortItems(groups)}
@@ -160,6 +162,7 @@ class ScheduleDetailContainer extends React.Component<Props> {
 
 export default compose(
   withRouter,
+  withGroupContext,
   graphql(GET_MY_GROUPS, {
     name: 'getGroups'
   }),

--- a/packages/client/src/ee/job.tsx
+++ b/packages/client/src/ee/job.tsx
@@ -18,6 +18,7 @@ import ScheduleDetailContainer from 'ee/containers/scheduleDetail';
 import ScheduleCreatePage from 'ee/containers/scheduleCreatePage';
 import ScheduleListContainer from 'ee/containers/scheduleList';
 import {appPrefix} from 'utils/env';
+import { GroupContext, GroupContextValue } from 'context/group';
 const HEADER_HEIGHT = 64;
 
 const Content = styled(Layout.Content)`
@@ -224,6 +225,8 @@ const client = genClient(process.env.NODE_ENV === 'production' ?
 
 class Job extends React.Component {
   render() {
+    const groupContext: GroupContextValue = JSON.parse(window.localStorage.getItem("group-context"));
+
     return (
       <BrowserRouter>
         <Layout>
@@ -231,6 +234,7 @@ class Job extends React.Component {
           <Layout>
             <Sidebar />
             <Content>
+              <GroupContext.Provider value={groupContext}>
                 <ApolloProvider client={client}>
                   <Switch>
                     <Route path={`${appPrefix}job`} exact>
@@ -257,6 +261,7 @@ class Job extends React.Component {
                     />
                   </Switch>
                 </ApolloProvider>
+              </GroupContext.Provider>
             </Content>
           </Layout>
         </Layout>

--- a/packages/client/src/ee/modelDeployment.tsx
+++ b/packages/client/src/ee/modelDeployment.tsx
@@ -55,7 +55,7 @@ const fakeData = {
   me: {
     groups: [{
       id: 'groupId1',
-      name: 'Group',
+      name: 'Group1',
       enabledDeployment: true,
       displayName: 'c-Group 1',
       instanceTypes: [{
@@ -70,8 +70,8 @@ const fakeData = {
       }]
     }, {
       id: 'groupId2',
-      name: 'Group',
-      enabledDeployment: true,
+      name: 'Group2',
+      enabledDeployment: false,
       displayName: 'Group 2',
       instanceTypes: [{
         id: 'ggit1',
@@ -85,7 +85,7 @@ const fakeData = {
       }]
     }, {
       id: 'everyone',
-      name: 'Group',
+      name: 'everyone',
       enabledDeployment: true,
       displayName: 'Group DisplayName',
       instanceTypes: [{
@@ -132,8 +132,8 @@ const fakeData = {
     batch3
     batch4
     `,
-    groupId: 'everyone',
-    groupName: 'groupName',
+    groupId: 'groupId1',
+    groupName: 'Group1',
     endpoint: 'https://endpoint/modedeployment/example/test/1',
     endpointAccessType: "private",
     endpointClients: [
@@ -172,7 +172,7 @@ const fakeData = {
         },
         name: 'd0',
         description: 'fdksoapfkeowpfadsangisoagdsagsgeiwagegiowagegeianogigeanogeiaogneiasogensioagenifdksoapfkeowpfadsangisoagdsagsgeiwagegiowagegeianogigeanogeiaogneiasogensioageni',
-        groupName: 'groupName',
+        groupName: 'Group1',
         modelImage: 'imageurl',
         replicas: 4,
         instanceType: {
@@ -201,8 +201,8 @@ const fakeData = {
     batch3
     batch4
     `,
-    groupId: 'everyone',
-    groupName: 'groupName',
+    groupId: 'groupId1',
+    groupName: 'Group1',
     endpoint: 'https://endpoint/mode-deployment/example/test/1',
     endpointAccessType: "private",
     endpointClients: [],
@@ -237,8 +237,8 @@ const fakeData = {
     batch3
     batch4
     `,
-    groupId: 'everyone',
-    groupName: 'groupName',
+    groupId: 'groupId1',
+    groupName: 'Group1',
     endpoint: 'https://endpoint/mode-deployment/example/test/1',
     modelImage: 'imageurl',
     pods: [
@@ -272,8 +272,8 @@ const fakeData = {
     batch3
     batch4
     `,
-    groupId: 'everyone',
-    groupName: 'groupName',
+    groupId: 'groupId1',
+    groupName: 'Group1',
     endpoint: 'https://endpoint/mode-deployment/example/test/1',
     modelImage: 'imageurl',
     pods: [
@@ -307,8 +307,8 @@ const fakeData = {
     batch3
     batch4
     `,
-    groupId: 'everyone',
-    groupName: 'groupName',
+    groupId: 'groupId1',
+    groupName: 'Group1',
     endpoint: 'https://endpoint/mode-deployment/example/test/1',
     modelImage: 'imageurl',
     pods: [],

--- a/packages/client/src/ee/modelDeployment.tsx
+++ b/packages/client/src/ee/modelDeployment.tsx
@@ -21,6 +21,7 @@ import 'moment/locale/zh-tw';
 import {IntlProvider, addLocaleData} from 'react-intl';
 addLocaleData([...en])
 import myLocales from '../utils/locales';
+import { GroupContextValue, GroupContext } from 'context/group';
 const locale = (window as any).LOCALE || 'en';
 
 
@@ -340,6 +341,8 @@ const client = genClient(process.env.NODE_ENV === 'production' ?
 
 class Job extends React.Component {
   render() {
+    const groupContext: GroupContextValue = JSON.parse(window.localStorage.getItem("group-context"));
+
     return (
       <IntlProvider locale={locale} messages={{...dict[locale], ...myLocales[locale]}}>
         <BrowserRouter>
@@ -347,27 +350,29 @@ class Job extends React.Component {
             <Header />
             <Layout>
               <Content style={{padding: 0}}>
-                <ApolloProvider client={client}>
-                  <Switch>
-                    <Route path={`${appPrefix}model-deployment`} exact>
-                      <ListContainer Com={ModelDeploymentListContainer} />
-                    </Route>
-                    <Route path={`${appPrefix}model-deployment/create`} exact>
-                      <DeploymentCreatePage />
-                    </Route>
-                    <Route
-                      path={`${appPrefix}model-deployment/:deploymentId`}
-                      exact
-                      component={DeploymentDetailContainer}
-                    />
-                    <Route
-                      path={`${appPrefix}model-deployment/edit/:deploymentId`}
-                      exact
-                    >
-                      <DeploymentEditPage />
-                    </Route>
-                  </Switch>
-                </ApolloProvider>
+                <GroupContext.Provider value={groupContext}>
+                  <ApolloProvider client={client}>
+                    <Switch>
+                      <Route path={`${appPrefix}model-deployment`} exact>
+                        <ListContainer Com={ModelDeploymentListContainer} />
+                      </Route>
+                      <Route path={`${appPrefix}model-deployment/create`} exact>
+                        <DeploymentCreatePage />
+                      </Route>
+                      <Route
+                        path={`${appPrefix}model-deployment/:deploymentId`}
+                        exact
+                        component={DeploymentDetailContainer}
+                      />
+                      <Route
+                        path={`${appPrefix}model-deployment/edit/:deploymentId`}
+                        exact
+                      >
+                        <DeploymentEditPage />
+                      </Route>
+                    </Switch>
+                  </ApolloProvider>
+                </GroupContext.Provider>
               </Content>
             </Layout>
           </Layout>

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -9,7 +9,9 @@
       "images/*": ["./src/images/*"],
       "components/*": ["./src/components/*"],
       "containers/*": ["./src/containers/*"],
-      "styledShare/*": ["./src/styled_share/*"]
+      "styledShare/*": ["./src/styled_share/*"],
+      "context/*": ["./src/context/*"],
+      "ee/*": ["./src/ee/*"]
     }
   },
   "exclude": ["dist", "build", "node_modules"]

--- a/packages/client/webpack.settings.js
+++ b/packages/client/webpack.settings.js
@@ -22,6 +22,7 @@ module.exports = {
       images: path.resolve(__dirname, 'src/images'),
       components: path.resolve(__dirname, 'src/components'),
       containers: path.resolve(__dirname, 'src/containers'),
+      context: path.resolve(__dirname, 'src/context'),
       ee: path.resolve(__dirname, 'src/ee'),
       root: path.resolve(__dirname, 'src'),
       schema: path.resolve(__dirname, 'schema')


### PR DESCRIPTION
## Story
https://app.clubhouse.io/infuseai/story/11269/group-context-aware-components-support-group-prop

## How to test
To simulate the group context. 

1. set the groupContext to localStorage
    ```
    > let groupContext = {
      "id": "ffbcea82-2ed7-4d3e-bd8e-02e7aa4e29aa",
      "displayName": "primehub users",
      "name": "phusers"
    }
    > window.localStorage.setItem("group-context", JSON.stringify(groupContext));
    ```
2. Reload the page.
3. Go to job and model deployment page.

Disable group context
1. remove the local storage
    ```
    window.localStorage.removeItem("group-context");
    ```
2. reload page

## Demo
Demo image:
`ch11269-05eb6d3`

Demo video
https://youtu.be/MLVD4Cv4ay4

