### PR TITLE
Enable model deployment only when option is enabled

### DIFF
--- a/packages/admin-server/src/views/main.pug
+++ b/packages/admin-server/src/views/main.pug
@@ -19,6 +19,7 @@ html
       window.requestApiTokenEndpoint = '#{requestApiTokenEndpoint}';
       window.apiToken = '#{apiToken}';
       window.enableLogPersistence = #{enableLogPersistence};
+      window.enableModelDeployment = #{enableModelDeployment};
 
       if (window.newAccessToken) {
         console.log('using new access token');

--- a/packages/client/docs/index.html
+++ b/packages/client/docs/index.html
@@ -36,6 +36,7 @@
     window.enableMaintenanceNotebook = true;
     window.enableGrafana = true;
     window.enableUsageReport = true;
+    window.enableModelDeployment = true;
     window.disableMode = false;
     window.absGraphqlEndpoint = 'http://localhost:3001/api/graphql';
     window.requestApiTokenEndpoint =  'http://localhost:3000/oidc/request-api-token';

--- a/packages/client/schema/jupyterhub.schema.js
+++ b/packages/client/schema/jupyterhub.schema.js
@@ -2,5 +2,5 @@
 import builder from 'canner-script';
 
 export default () => (
-  <object keyName="jupyterhub" title="Jupterhub Admin"></object>
+  <object keyName="jupyterhub" title="Jupyterhub Admin"></object>
 )

--- a/packages/client/src/cms.tsx
+++ b/packages/client/src/cms.tsx
@@ -179,7 +179,7 @@ export default class CMSPage extends React.Component<Props, State> {
         if (data) client.clearStore();
       } catch {}
     }
-    
+
     return {
       query,
       variables: newVariables
@@ -480,8 +480,7 @@ export default class CMSPage extends React.Component<Props, State> {
       <Layout style={{minHeight: '100vh'}}>
         <ContentHeader/>
         <Layout style={{marginTop: 64}}>
-          <Sider breakpoint="sm"
-            style={{
+          <Sider style={{
               position: "fixed",
               height: "100%"
             }}

--- a/packages/client/src/components/main/sidebar.tsx
+++ b/packages/client/src/components/main/sidebar.tsx
@@ -61,7 +61,7 @@ class Sidebar extends React.Component<Props> {
     const group = get(match, 'params.groupName', '');
 
     return (
-      <Layout.Sider style={{paddingTop: 64}}>
+      <Layout.Sider style={{position: 'fixed', height: '100%'}}>
         <Menu
           theme="dark"
           selectedKeys={[key]}

--- a/packages/client/src/containers/mainPage.tsx
+++ b/packages/client/src/containers/mainPage.tsx
@@ -15,14 +15,6 @@ import { GroupContextValue, GroupContext } from 'context/group';
 import { Landing } from '../landing';
 import ApiTokenPage from 'containers/apiTokenPage';
 
-const HEADER_HEIGHT = 64;
-
-const Content = styled(Layout.Content)`
-  margin-top: ${HEADER_HEIGHT}px;
-  padding: 24;
-  min-height: calc(100vh - 64px);
-`;
-
 export const GroupFragment = gql`
   fragment GroupInfo on Group {
     id
@@ -127,11 +119,11 @@ export class MainPage extends React.Component<MainPageProps, MainPageState> {
               />
             </Route>
           </Switch>
-          <Layout>
+          <Layout style={{marginTop: 64}}>
             <Route path={`${appPrefix}g/:groupName`}>
               <Sidebar sidebarItems={sidebarItems}/>
             </Route>
-            <Content>
+            <Layout.Content style={{marginLeft: 200,  minHeight: 'calc(100vh - 64px)'}}>
               <Switch>
                 {/* Home */}
                 <Route path={`${appPrefix}g/:groupName`} exact>
@@ -151,7 +143,7 @@ export class MainPage extends React.Component<MainPageProps, MainPageState> {
                   <Landing includeHeader={false} />
                 </Route>
               </Switch>
-            </Content>
+            </Layout.Content>
           </Layout>
         </Layout>
       </GroupContext.Provider>

--- a/packages/client/src/ee/containers/modelDeploymentList.tsx
+++ b/packages/client/src/ee/containers/modelDeploymentList.tsx
@@ -19,7 +19,7 @@ import { PhDeploymentFragment, DeploymentConnection } from 'ee/components/modelD
 import InfuseButton from 'components/infuseButton';
 import { GroupContextComponentProps } from 'context/group';
 
-const PAGE_SIZE = 8;
+const PAGE_SIZE = 12;
 const Search = Input.Search
 
 export const GET_PH_DEPLOYMENT_CONNECTION = gql`

--- a/packages/client/src/ee/main.model_deploy.tsx
+++ b/packages/client/src/ee/main.model_deploy.tsx
@@ -31,7 +31,14 @@ class Main extends React.Component {
       {
         title: 'Models',
         subPath: 'model-deployment',
-        icon: iconModels
+        icon: iconModels,
+        style: {
+          width: 'auto',
+          height: 16,
+          marginLeft: '2px',
+          marginRight: '-2px',
+          marginTop: '-5px',
+        }
       },
     ]
 

--- a/packages/client/src/ee/main.tsx
+++ b/packages/client/src/ee/main.tsx
@@ -75,6 +75,10 @@ class Main extends React.Component {
           marginTop: '-5px',
         }
       },
+    ] ;
+
+    if ((window as any).enableModelDeployment) {
+      sidebarItems.push(
       {
         title: 'Models',
         subPath: 'model-deployment',
@@ -87,8 +91,8 @@ class Main extends React.Component {
           marginRight: '-2px',
           marginTop: '-5px',
         }
-      },
-    ]
+      });
+    }
 
     return (
       <BrowserRouter>

--- a/packages/client/src/main.ce.tsx
+++ b/packages/client/src/main.ce.tsx
@@ -99,6 +99,13 @@ class Main extends React.Component {
         title: 'JupyterHub',
         subPath: 'hub',
         icon: iconJupyterHub,
+        style: {
+          width: 'auto',
+          height: 22,
+          marginRight: '-3px',
+          marginLeft: '-2px',
+          marginTop: '-2px'
+        }
       },
     ]
 


### PR DESCRIPTION
## Story
https://app.clubhouse.io/infuseai/story/11996/should-enable-model-deployment-by-primehub-chart-option

## What's in this PR
- Show model deployment menu item only when model deployment is enabled.
- Fix the ce/deployment menu item layout
- Make the side menu not scrolling with the main content (same as admin portal)

## Demo Image
ch11996-62986a9