### PR TITLE
Changes to use manual configuration for OIDC endpoints

### DIFF
--- a/packages/admin-server/package.json
+++ b/packages/admin-server/package.json
@@ -33,7 +33,7 @@
     "json-stream": "^1.0.0",
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^8.3.0",
-    "keycloak-admin": "^1.6.1",
+    "keycloak-admin": "npm:@infuseai/keycloak-admin@1.12.3",
     "koa": "^2.5.2",
     "koa-bodyparser": "^4.2.1",
     "koa-morgan": "^1.0.1",

--- a/packages/admin-server/src/app.ts
+++ b/packages/admin-server/src/app.ts
@@ -46,7 +46,14 @@ export const createApp = async (): Promise<{app: Koa, config: Config}> => {
   };
 
   // tslint:disable-next-line:max-line-length
-  const issuer = await Issuer.discover(`${config.keycloakOidcBaseUrl}/realms/${config.keycloakRealmName}/.well-known/openid-configuration`);
+  const issuer =  new Issuer({
+    issuer: `${config.keycloakOidcBaseUrl}/realms/${config.keycloakRealmName}`,
+    authorization_endpoint: `${config.keycloakOidcBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/auth`,
+    token_endpoint: `${config.keycloakApiBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/token`,
+    userinfo_endpoint: `${config.keycloakApiBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/userinfo`,
+    jwks_uri: `${config.keycloakApiBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/certs`,
+  });
+
   const oidcClient = new issuer.Client({
     client_id: config.keycloakClientId,
     client_secret: config.keycloakClientSecret

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -57,7 +57,7 @@
     "json-stream": "^1.0.0",
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^8.3.0",
-    "keycloak-admin": "^1.6.1",
+    "keycloak-admin": "npm:@infuseai/keycloak-admin@1.12.3",
     "koa": "^2.5.2",
     "koa-bodyparser": "^4.2.1",
     "koa-morgan": "^1.0.1",

--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -16,6 +16,7 @@ import WorkspaceApi from '../workspace/api';
 import { keycloakMaxCount } from '../resolvers/constant';
 import request from 'request';
 import mime from 'mime';
+import url from 'url';
 
 import CrdClient, { InstanceTypeSpec, ImageSpec, client as kubeClient, kubeConfig } from '../crdClient/crdClientImpl';
 import * as system from '../resolvers/system';
@@ -238,7 +239,13 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
   };
 
   // tslint:disable-next-line:max-line-length
-  const issuer = await Issuer.discover(`${config.keycloakOidcBaseUrl}/realms/${config.keycloakRealmName}/.well-known/openid-configuration`);
+  const issuer =  new Issuer({
+    issuer: `${config.keycloakOidcBaseUrl}/realms/${config.keycloakRealmName}`,
+    authorization_endpoint: `${config.keycloakOidcBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/auth`,
+    token_endpoint: `${config.keycloakApiBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/token`,
+    userinfo_endpoint: `${config.keycloakApiBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/userinfo`,
+    jwks_uri: `${config.keycloakApiBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/certs`,
+  });
   const oidcClient = new issuer.Client({
     client_id: config.keycloakClientId,
     client_secret: config.keycloakClientSecret
@@ -252,14 +259,22 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
   // init
   await oidcTokenVerifier.initKeystore();
 
-  const createKcAdminClient = () => new KcAdminClient({
-    baseUrl: config.keycloakApiBaseUrl,
-    realmName: config.keycloakRealmName,
-    requestConfig: {
-      httpAgent,
-      httpsAgent
-    }
-  });
+  const createKcAdminClient = (tokenIssuer?: string) => {
+    const kcAdminClientHeaders = tokenIssuer ? {
+      'Host': url.parse(tokenIssuer).hostname,
+      'X-Forwarded-Proto': url.parse(tokenIssuer).protocol.slice(0, -1),
+    } : {};
+
+    return new KcAdminClient({
+      baseUrl: config.keycloakApiBaseUrl,
+      realmName: config.keycloakRealmName,
+      requestConfig: {
+        httpAgent,
+        httpsAgent,
+        headers: kcAdminClientHeaders,
+      }
+    });
+  };
 
   const crdClient = new CrdClient({
     namespace: config.k8sCrdNamespace
@@ -374,7 +389,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
       let getInstanceType: (name: string) => Promise<Item<InstanceTypeSpec>>;
       let getImage: (name: string) => Promise<Item<ImageSpec>>;
 
-      const kcAdminClient = createKcAdminClient();
+      let kcAdminClient;
       const keycloakClientId = config.keycloakClientId;
       const {authorization = ''}: {authorization: string} = ctx.header;
       const useCache = ctx.headers['x-primehub-use-cache'];
@@ -391,6 +406,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
           // since it's from jupyterHub
           // we use batch for crd resource get method
           const accessToken = await tokenSyncer.getAccessToken();
+          kcAdminClient = createKcAdminClient();
           kcAdminClient.setAccessToken(accessToken);
           getInstanceType = instCache.get;
           getImage = imageCache.get;
@@ -420,6 +436,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
           }
           userId = tokenPayload.sub;
           username = tokenPayload.preferred_username;
+          kcAdminClient = createKcAdminClient(tokenPayload.iss);
 
           // check if user is admin
           const roles = get(tokenPayload, ['resource_access', 'realm-management', 'roles'], []);
@@ -644,7 +661,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
       }
 
       // Prepare keycloak admin client
-      const kcAdminClient = createKcAdminClient();
+      const kcAdminClient = createKcAdminClient(tokenPayload.iss);
       kcAdminClient.setAccessToken(apiToken);
       ctx.kcAdminClient = kcAdminClient;
 

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -26,7 +26,7 @@
     "boom": "^7.2.0",
     "debug": "^3.1.0",
     "js-yaml": "^3.12.0",
-    "keycloak-admin": "^1.6.1",
+    "keycloak-admin": "npm:@infuseai/keycloak-admin@1.12.3",
     "koa": "^2.5.2",
     "koa-bodyparser": "^4.2.1",
     "koa-morgan": "^1.0.1",

--- a/packages/watcher/src/app.ts
+++ b/packages/watcher/src/app.ts
@@ -41,7 +41,13 @@ export const createApp = async (): Promise<{app: Koa, config: Config}> => {
   };
 
   // tslint:disable-next-line:max-line-length
-  const issuer = await Issuer.discover(`${config.keycloakOidcBaseUrl}/realms/${config.keycloakRealmName}/.well-known/openid-configuration`);
+  const issuer =  new Issuer({
+    issuer: `${config.keycloakOidcBaseUrl}/auth/realms/${config.keycloakRealmName}`,
+    authorization_endpoint: `${config.keycloakOidcBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/auth`,
+    token_endpoint: `${config.keycloakApiBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/token`,
+    userinfo_endpoint: `${config.keycloakApiBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/userinfo`,
+    jwks_uri: `${config.keycloakApiBaseUrl}/realms/${config.keycloakRealmName}/protocol/openid-connect/certs`,
+  });
   const oidcClient = new issuer.Client({
     client_id: config.keycloakClientId,
     client_secret: config.keycloakClientSecret

--- a/yarn.lock
+++ b/yarn.lock
@@ -11082,10 +11082,10 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-keycloak-admin@^1.6.1:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/keycloak-admin/-/keycloak-admin-1.13.0.tgz#f6e6de0551155b228d8a551531096d7b4c9ff23f"
-  integrity sha512-FIQGEqlVYnegIcTia1o5UIAR6iJR7moixo9YwsNe8zGhqsdMTo1lbAsWcS5aaGzfprL5Zyjk4O8BfbI/55pwmg==
+"keycloak-admin@npm:@infuseai/keycloak-admin@1.12.3":
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/@infuseai/keycloak-admin/-/keycloak-admin-1.12.3.tgz#e9c87d592c03ed897e1db01610e80bbd62e9bb28"
+  integrity sha512-0jbh8UIjCsRx54iKtgJQWQ7cJVIZRSjyCRXSd9NdJ4hXF9LIf9CbWSjMBP20Im1Wa2yZh+gLMZ61l6pkIIWvGw==
   dependencies:
     "@types/debug" "^0.0.30"
     axios "^0.18.0"
@@ -11967,10 +11967,15 @@ lodash.values@~2.4.1:
   dependencies:
     lodash.keys "~2.4.1"
 
-lodash@4, lodash@^4.0.1, lodash@^4.14.2, lodash@^4.16.2, lodash@^4.16.5, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4, lodash@^4.0.1, lodash@^4.14.2, lodash@^4.16.2, lodash@^4.16.5, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.10:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 lodash@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
In this change, the env 'KC_API_BASEURL' can be set as in-cluster service URL. I make sure these work

1. OIDC relative task (login, logout, get api token)
1. Use keycloak admin with client token
1. Use keycloak admin with user token
1. Use keycloak admin with API token

## Story
https://app.clubhouse.io/infuseai/story/12109/review-and-modify-primehub-console-to-support-default-use-internal-url-to-connect-keycloak-for-oidc

## Demo
ch12109-a7293c4

## Test cases

1. OIDC URL = API URL

- [x] Console  Login
- [x] Console Logout
- [x] Console Request API token
- [x] GraphQL API call from api token
- [x] GraphQL API call from user token
- [x] GraphQL API call from shared secret
- [x] Watcher: Add/Remove role while adding CRD

2. OIDC URL != API URL

- [x] Console Login
- [x] Console Logout
- [x] Console Request API token
- [x] GraphQL API call from api token
- [x] GraphQL API call from user token
- [x] GraphQL API call from shared secret
- [x] Watcher: Add/Remove role while adding CRD

The full test process is in this video
https://www.youtube.com/watch?v=UnpJFmnj11o