### PR TITLE
Feature/ch12332/job show resource information in job submission

### DIFF
--- a/packages/client/src/containers/list.tsx
+++ b/packages/client/src/containers/list.tsx
@@ -15,6 +15,17 @@ export const GroupFragment = gql`
     id
     displayName
     name
+    quotaCpu
+    quotaGpu
+    quotaMemory
+    datasets {
+      displayName
+    }
+    resourceStatus {
+      cpuUsage
+      memUsage
+      gpuUsage
+    }
     enabledDeployment
   }
 `;

--- a/packages/client/src/ee/components/job/createForm.tsx
+++ b/packages/client/src/ee/components/job/createForm.tsx
@@ -241,6 +241,7 @@ class CreateForm extends React.Component<Props, State> {
       message,
     } = initialValue || {};
     let recurrenceLabel = `Recurrence Options`;
+    console.log(groupContext);
     if (timezone) {
       recurrenceLabel += `(${this.stringifyZone(timezone, 'GMT')})`;
     }
@@ -453,32 +454,35 @@ class CreateForm extends React.Component<Props, State> {
                 <tbody>
                   <tr>
                     <td>CPU</td>
-                    <td>3</td>
-                    <td>32</td>
+                    <td>{groupContext.resourceStatus.cpuUsage}</td>
+                    <td>{groupContext.quotaCpu == null ? '∞' : groupContext.quotaCpu}</td>
                   </tr>
                   <tr>
                     <td>Memory</td>
-                    <td>6 GB</td>
-                    <td>200 GB</td>
+                    <td>{groupContext.resourceStatus.memUsage} GB</td>
+                    <td>{groupContext.quotaMemory == null ? '∞' : `${groupContext.quotaMemory} GB`} </td>
                   </tr>
                   <tr>
                     <td>GPU</td>
-                    <td> 0 </td>
-                    <td> 4 </td>
+                    <td>{groupContext.resourceStatus.gpuUsage} </td>
+                    <td>{groupContext.quotaGpu == null ? '∞' : groupContext.quotaGpu}</td>
                   </tr>
                 </tbody>
               </Table>
             </Card>
             <Card style={{overflow: 'auto'}}>
               <h3>Datasets</h3>
-              <ul>
-                <li>test-env</li>
-                <li>praticalAI</li>
-                <li>tensorflow-dataset</li>
-                <li>test-mount</li>
-                <li>first-day-with-python</li>
-                <li>TensorBoard Demo</li>
-              </ul>
+              {
+                groupContext.datasets.length ? (
+                <ul>
+                  {
+                    groupContext.datasets.map(dataset =>(<li>{dataset.displayName}</li>))
+                  }
+                </ul>
+                ) : (
+                  <div> No available dataset </div>
+                )
+              }
             </Card>
           </Col>
         </Row>

--- a/packages/client/src/ee/components/job/createForm.tsx
+++ b/packages/client/src/ee/components/job/createForm.tsx
@@ -4,33 +4,10 @@ import {FormComponentProps} from 'antd/lib/form';
 import {get, startCase} from 'lodash';
 import RecurrenceInput, {RecurrenceType, recurrenceValidator} from 'ee/components/schedule/recurrence';
 import Message from 'components/share/message';
-import styled from 'styled-components'
+import styled from 'styled-components';
+import ResourceMonitor from 'ee/components/shared/resourceMonitor';
 
 const { Option } = Select;
-
-const Table = styled.table`
-  width: 100%;
-  td, th {
-    line-height: 2.5em;
-    padding-left: 5px;
-  }
-
-  th {
-    border-bottom: 2px solid #AAA;
-  }
-
-  td {
-    border-bottom: 1px solid #DDD;
-  }
-
-  tbody > tr:nth-child(odd) {
-    background-color: #FAFAFA;
-  }
-
-  tr > td:first-child {
-    font-weight: bold;
-  }
-`;
 
 type Props = FormComponentProps & {
   groupContext?: any;
@@ -441,49 +418,7 @@ class CreateForm extends React.Component<Props, State> {
             </Form.Item>
           </Col>
           <Col xs="24" sm="8" lg="8">
-            <Card style={{overflow: 'auto'}}>
-              <h3>Group Resource</h3>
-              <Table>
-                <thead>
-                  <tr>
-                    <th>Type</th>
-                    <th>Used</th>
-                    <th>Limit</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>CPU</td>
-                    <td>{groupContext.resourceStatus.cpuUsage}</td>
-                    <td>{groupContext.quotaCpu == null ? '∞' : groupContext.quotaCpu}</td>
-                  </tr>
-                  <tr>
-                    <td>Memory</td>
-                    <td>{groupContext.resourceStatus.memUsage} GB</td>
-                    <td>{groupContext.quotaMemory == null ? '∞' : `${groupContext.quotaMemory} GB`} </td>
-                  </tr>
-                  <tr>
-                    <td>GPU</td>
-                    <td>{groupContext.resourceStatus.gpuUsage} </td>
-                    <td>{groupContext.quotaGpu == null ? '∞' : groupContext.quotaGpu}</td>
-                  </tr>
-                </tbody>
-              </Table>
-            </Card>
-            <Card style={{overflow: 'auto'}}>
-              <h3>Datasets</h3>
-              {
-                groupContext.datasets.length ? (
-                <ul>
-                  {
-                    groupContext.datasets.map(dataset =>(<li>{dataset.displayName}</li>))
-                  }
-                </ul>
-                ) : (
-                  <div> No available dataset </div>
-                )
-              }
-            </Card>
+            <ResourceMonitor groupContext={groupContext}/>
           </Col>
         </Row>
       </Form>

--- a/packages/client/src/ee/components/job/createForm.tsx
+++ b/packages/client/src/ee/components/job/createForm.tsx
@@ -218,7 +218,6 @@ class CreateForm extends React.Component<Props, State> {
       message,
     } = initialValue || {};
     let recurrenceLabel = `Recurrence Options`;
-    console.log(groupContext);
     if (timezone) {
       recurrenceLabel += `(${this.stringifyZone(timezone, 'GMT')})`;
     }

--- a/packages/client/src/ee/components/job/createForm.tsx
+++ b/packages/client/src/ee/components/job/createForm.tsx
@@ -10,6 +10,7 @@ import ResourceMonitor from 'ee/components/shared/resourceMonitor';
 const { Option } = Select;
 
 type Props = FormComponentProps & {
+  showResources: boolean;
   refetchGroup: Function;
   groupContext?: any;
   groups: Array<Record<string, any>>;
@@ -189,6 +190,7 @@ class CreateForm extends React.Component<Props, State> {
 
   render() {
     const {
+      showResources,
       refetchGroup,
       groupContext,
       groups,
@@ -420,12 +422,18 @@ class CreateForm extends React.Component<Props, State> {
             </Form.Item>
           </Col>
           <Col xs="24" sm="8" lg="8">
-            <ResourceMonitor
-              groupContext={groupContext}
-              refetchGroup={refetchGroup}
-              selectedGroup={selectedGroup}
-              showDataset={true}
-            />
+            {
+              showResources ? (
+                <ResourceMonitor
+                  groupContext={groupContext}
+                  refetchGroup={refetchGroup}
+                  selectedGroup={selectedGroup}
+                  showDataset={true}
+                />
+              ) : (
+                <></>
+              )
+            }
           </Col>
         </Row>
       </Form>

--- a/packages/client/src/ee/components/job/createForm.tsx
+++ b/packages/client/src/ee/components/job/createForm.tsx
@@ -4,8 +4,33 @@ import {FormComponentProps} from 'antd/lib/form';
 import {get, startCase} from 'lodash';
 import RecurrenceInput, {RecurrenceType, recurrenceValidator} from 'ee/components/schedule/recurrence';
 import Message from 'components/share/message';
+import styled from 'styled-components'
 
 const { Option } = Select;
+
+const Table = styled.table`
+  width: 100%;
+  td, th {
+    line-height: 2.5em;
+    padding-left: 5px;
+  }
+
+  th {
+    border-bottom: 2px solid #AAA;
+  }
+
+  td {
+    border-bottom: 1px solid #DDD;
+  }
+
+  tbody > tr:nth-child(odd) {
+    background-color: #FAFAFA;
+  }
+
+  tr > td:first-child {
+    font-weight: bold;
+  }
+`;
 
 type Props = FormComponentProps & {
   groupContext?: any;
@@ -248,7 +273,7 @@ class CreateForm extends React.Component<Props, State> {
     return (
       <Form onSubmit={this.submit}>
         <Row gutter={16}>
-          <Col xs={24} sm={8} lg={8}>
+          <Col xs={24} sm={16} lg={16}>
             <Card loading={loading} style={{overflow: 'auto'}}>
               <h3>Environment Settings</h3>
               <Divider />
@@ -337,8 +362,6 @@ class CreateForm extends React.Component<Props, State> {
               </Form.Item>
 
             </Card>
-          </Col>
-          <Col xs={24} sm={16} lg={16}>
             <Card>
               <h3>{startCase(type || 'job')} Details</h3>
               <Divider />
@@ -404,17 +427,59 @@ class CreateForm extends React.Component<Props, State> {
               {
                 <Button
                   type="primary" htmlType="submit"
-                  style={{marginRight: onCancel ? 16 : 0}}
+                  style={{width: "100%"}}
                 >
                   {submitText || 'Submit'}
                 </Button>
               }
               {
-                onCancel && <Button onClick={this.cancel}>
+                onCancel && <Button onClick={this.cancel} style={{width: "100%"}}>
                   Cancel
                 </Button>
               }
             </Form.Item>
+          </Col>
+          <Col xs="24" sm="8" lg="8">
+            <Card style={{overflow: 'auto'}}>
+              <h3>Group Resource</h3>
+              <Table>
+                <thead>
+                  <tr>
+                    <th>Type</th>
+                    <th>Used</th>
+                    <th>Limit</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>CPU</td>
+                    <td>3</td>
+                    <td>32</td>
+                  </tr>
+                  <tr>
+                    <td>Memory</td>
+                    <td>6 GB</td>
+                    <td>200 GB</td>
+                  </tr>
+                  <tr>
+                    <td>GPU</td>
+                    <td> 0 </td>
+                    <td> 4 </td>
+                  </tr>
+                </tbody>
+              </Table>
+            </Card>
+            <Card style={{overflow: 'auto'}}>
+              <h3>Datasets</h3>
+              <ul>
+                <li>test-env</li>
+                <li>praticalAI</li>
+                <li>tensorflow-dataset</li>
+                <li>test-mount</li>
+                <li>first-day-with-python</li>
+                <li>TensorBoard Demo</li>
+              </ul>
+            </Card>
           </Col>
         </Row>
       </Form>

--- a/packages/client/src/ee/components/job/createForm.tsx
+++ b/packages/client/src/ee/components/job/createForm.tsx
@@ -10,6 +10,7 @@ import ResourceMonitor from 'ee/components/shared/resourceMonitor';
 const { Option } = Select;
 
 type Props = FormComponentProps & {
+  refetchGroup: Function;
   groupContext?: any;
   groups: Array<Record<string, any>>;
   onSelectGroup: Function;
@@ -188,6 +189,7 @@ class CreateForm extends React.Component<Props, State> {
 
   render() {
     const {
+      refetchGroup,
       groupContext,
       groups,
       onSelectGroup,
@@ -200,6 +202,7 @@ class CreateForm extends React.Component<Props, State> {
       timezone,
       onCancel,
       submitText,
+      selectedGroup
     } = this.props;
     const {
       recurrenceError
@@ -417,7 +420,12 @@ class CreateForm extends React.Component<Props, State> {
             </Form.Item>
           </Col>
           <Col xs="24" sm="8" lg="8">
-            <ResourceMonitor groupContext={groupContext}/>
+            <ResourceMonitor
+              groupContext={groupContext}
+              refetchGroup={refetchGroup}
+              selectedGroup={selectedGroup}
+              showDataset={true}
+            />
           </Col>
         </Row>
       </Form>

--- a/packages/client/src/ee/components/job/createForm.tsx
+++ b/packages/client/src/ee/components/job/createForm.tsx
@@ -400,7 +400,7 @@ class CreateForm extends React.Component<Props, State> {
                 )
               }
             </Card>
-            <Form.Item style={{textAlign: 'right', marginRight: 8, marginTop: 24}}>
+            <Form.Item style={{textAlign: 'right', marginTop: 12}}>
               {
                 <Button
                   type="primary" htmlType="submit"

--- a/packages/client/src/ee/components/modelDeployment/createForm.tsx
+++ b/packages/client/src/ee/components/modelDeployment/createForm.tsx
@@ -11,6 +11,7 @@ const { Option } = Select;
 
 type Props = FormComponentProps & {
   groupContext: any;
+  refetchGroup: Function;
   groups: Array<Record<string, any>>;
   onSelectGroup?: Function;
   selectedGroup: string;
@@ -145,6 +146,7 @@ class DeploymentCreateForm extends React.Component<Props, State> {
   render() {
     const {
       groupContext,
+      refetchGroup,
       groups,
       onSelectGroup,
       instanceTypes,
@@ -375,7 +377,11 @@ class DeploymentCreateForm extends React.Component<Props, State> {
             </Form.Item>
           </Col>
           <Col xs="24" sm="8" lg="8">
-            <ResourceMonitor groupContext={groupContext}/>
+            <ResourceMonitor
+              selectedGroup={selectedGroup}
+              groupContext={groupContext}
+              refetchGroup={refetchGroup}
+            />
           </Col>
         </Row>
       </Form>

--- a/packages/client/src/ee/components/modelDeployment/createForm.tsx
+++ b/packages/client/src/ee/components/modelDeployment/createForm.tsx
@@ -5,6 +5,7 @@ import {get, snakeCase, debounce} from 'lodash';
 import DynamicFields from 'components/share/dynamicFields';
 import InfuseButton from 'components/infuseButton';
 import ImagePullSecret from 'components/share/ImagePullSecret';
+import ResourceMonitor from 'ee/components/shared/resourceMonitor';
 
 const { Option } = Select;
 
@@ -371,6 +372,9 @@ class DeploymentCreateForm extends React.Component<Props, State> {
                 )
               }
             </Form.Item>
+          </Col>
+          <Col xs="24" sm="8" lg="8">
+            <ResourceMonitor groupContext={groupContext}/>
           </Col>
         </Row>
       </Form>

--- a/packages/client/src/ee/components/modelDeployment/createForm.tsx
+++ b/packages/client/src/ee/components/modelDeployment/createForm.tsx
@@ -214,25 +214,25 @@ class DeploymentCreateForm extends React.Component<Props, State> {
                   </Form.Item>
                 )
               }
-            <Form.Item label={`Deployment name`}>
-              {form.getFieldDecorator('name', {
-                initialValue: name,
-                rules: [
-                  { whitespace: true, required: true, message: 'Please input a name!' },
-                  { pattern: /^[a-zA-Z0-9][a-zA-Z0-9\s-_]*/, message: `alphanumeric characters, '-' or '_' , and must start with an alphanumeric character.`}
-                ],
-              })(
-                <Input disabled={type === 'edit'} onChange={this.handleNameChange} />
-              )}
-            </Form.Item>
-            <Form.Item label={`Deployment ID`}>
-              {form.getFieldDecorator('id', {
-                initialValue: id
-              })(
-                <Input disabled />
-              )}
-            </Form.Item>
             <Card loading={loading} style={{overflow: 'auto'}}>
+              <Form.Item label={`Deployment name`} style={{marginBottom: '8px'}}>
+                {form.getFieldDecorator('name', {
+                  initialValue: name,
+                  rules: [
+                    { whitespace: true, required: true, message: 'Please input a name!' },
+                    { pattern: /^[a-zA-Z0-9][a-zA-Z0-9\s-_]*/, message: `alphanumeric characters, '-' or '_' , and must start with an alphanumeric character.`}
+                  ],
+                })(
+                  <Input disabled={type === 'edit'} onChange={this.handleNameChange} />
+                )}
+              </Form.Item>
+              <Form.Item label={`Deployment ID`}>
+                {form.getFieldDecorator('id', {
+                  initialValue: id
+                })(
+                  <Input disabled />
+                )}
+              </Form.Item>
               <h3>Environment Settings</h3>
 
               <Row gutter={16}>
@@ -351,23 +351,23 @@ class DeploymentCreateForm extends React.Component<Props, State> {
             </Form.Item>
             </Card>
       </Row>
-            <Form.Item style={{textAlign: 'right', marginRight: 8, marginTop: 24}}>
+            <Form.Item style={{textAlign: 'right', marginTop: 12}}>
               {
                 type === 'edit' ? (
                   <>
                     <InfuseButton
                       type="primary"
                       htmlType="submit"
-                      style={{marginRight: 16, width: 'auto'}}
+                      style={{marginRight: 16, width: '100%'}}
                     >
                       Confirm and Deploy
                     </InfuseButton>
-                    <InfuseButton onClick={this.cancel}>
+                    <InfuseButton onClick={this.cancel} style={{width: "100%"}}>
                       Cancel
                     </InfuseButton>
                   </>
                 ) : (
-                  <InfuseButton type="primary" htmlType="submit">
+                  <InfuseButton type="primary" htmlType="submit" style={{width: "100%"}}>
                     Deploy
                   </InfuseButton>
                 )

--- a/packages/client/src/ee/components/modelDeployment/createForm.tsx
+++ b/packages/client/src/ee/components/modelDeployment/createForm.tsx
@@ -185,6 +185,7 @@ class DeploymentCreateForm extends React.Component<Props, State> {
       <span>The instance type <b>{instanceTypeName}</b> was deleted.</span>
     )
 
+
     return (
       <Form onSubmit={this.submit}>
         <Row gutter={16}>

--- a/packages/client/src/ee/components/shared/resourceMonitor.tsx
+++ b/packages/client/src/ee/components/shared/resourceMonitor.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import {Card, Divider} from 'antd';
+import styled from 'styled-components'
+
+type Props = {
+  groupContext: any;
+}
+
+type State = {
+}
+
+const Table = styled.table`
+  width: 100%;
+  td, th {
+    line-height: 2.5em;
+    padding-left: 5px;
+  }
+
+  th {
+    border-bottom: 2px solid #AAA;
+  }
+
+  td {
+    border-bottom: 1px solid #DDD;
+  }
+
+  tbody > tr:nth-child(odd) {
+    background-color: #FAFAFA;
+  }
+
+  tr > td:first-child {
+    font-weight: bold;
+  }
+`;
+
+export default class ResrouceMonitor extends React.Component<Props, State> {
+  render() {
+    const {
+      groupContext,
+    } = this.props;
+    return (
+      <>
+          <Card style={{overflow: 'auto'}}>
+            <h3>Group Resource</h3>
+            <Table>
+              <thead>
+                <tr>
+                  <th>Type</th>
+                  <th>Used</th>
+                  <th>Limit</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>CPU</td>
+                  <td>{groupContext.resourceStatus.cpuUsage}</td>
+                  <td>{groupContext.quotaCpu == null ? '∞' : groupContext.quotaCpu}</td>
+                </tr>
+                <tr>
+                  <td>Memory</td>
+                  <td>{groupContext.resourceStatus.memUsage} GB</td>
+                  <td>{groupContext.quotaMemory == null ? '∞' : `${groupContext.quotaMemory} GB`} </td>
+                </tr>
+                <tr>
+                  <td>GPU</td>
+                  <td>{groupContext.resourceStatus.gpuUsage} </td>
+                  <td>{groupContext.quotaGpu == null ? '∞' : groupContext.quotaGpu}</td>
+                </tr>
+              </tbody>
+            </Table>
+          </Card>
+          <Card style={{overflow: 'auto'}}>
+            <h3>Datasets</h3>
+            {
+              groupContext.datasets.length ? (
+              <ul>
+                {
+                  groupContext.datasets.map(dataset =>(<li>{dataset.displayName}</li>))
+                }
+              </ul>
+              ) : (
+                <div> No available dataset </div>
+              )
+            }
+          </Card>
+      </>
+    );
+  }
+}

--- a/packages/client/src/ee/components/shared/resourceMonitor.tsx
+++ b/packages/client/src/ee/components/shared/resourceMonitor.tsx
@@ -87,6 +87,6 @@ export default class ResrouceMonitor extends React.Component<Props, State> {
         </>
       );
     }
-    return <Card>Somthing Wrong.</Card>
+    return <Card style={{overflow: 'auto'}}>Oops, somthing wrong.</Card>
   }
 }

--- a/packages/client/src/ee/components/shared/resourceMonitor.tsx
+++ b/packages/client/src/ee/components/shared/resourceMonitor.tsx
@@ -38,52 +38,55 @@ export default class ResrouceMonitor extends React.Component<Props, State> {
     const {
       groupContext,
     } = this.props;
-    return (
-      <>
-          <Card style={{overflow: 'auto'}}>
-            <h3>Group Resource</h3>
-            <Table>
-              <thead>
-                <tr>
-                  <th>Type</th>
-                  <th>Used</th>
-                  <th>Limit</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>CPU</td>
-                  <td>{groupContext.resourceStatus.cpuUsage}</td>
-                  <td>{groupContext.quotaCpu == null ? '∞' : groupContext.quotaCpu}</td>
-                </tr>
-                <tr>
-                  <td>Memory</td>
-                  <td>{groupContext.resourceStatus.memUsage} GB</td>
-                  <td>{groupContext.quotaMemory == null ? '∞' : `${groupContext.quotaMemory} GB`} </td>
-                </tr>
-                <tr>
-                  <td>GPU</td>
-                  <td>{groupContext.resourceStatus.gpuUsage} </td>
-                  <td>{groupContext.quotaGpu == null ? '∞' : groupContext.quotaGpu}</td>
-                </tr>
-              </tbody>
-            </Table>
-          </Card>
-          <Card style={{overflow: 'auto'}}>
-            <h3>Datasets</h3>
-            {
-              groupContext.datasets.length ? (
-              <ul>
-                {
-                  groupContext.datasets.map(dataset =>(<li>{dataset.displayName}</li>))
-                }
-              </ul>
-              ) : (
-                <div> No available dataset </div>
-              )
-            }
-          </Card>
-      </>
-    );
+    if (groupContext) {
+      return (
+        <>
+            <Card style={{overflow: 'auto'}}>
+              <h3>Group Resource</h3>
+              <Table>
+                <thead>
+                  <tr>
+                    <th>Type</th>
+                    <th>Used</th>
+                    <th>Limit</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>CPU</td>
+                    <td>{groupContext.resourceStatus.cpuUsage}</td>
+                    <td>{groupContext.quotaCpu == null ? '∞' : groupContext.quotaCpu}</td>
+                  </tr>
+                  <tr>
+                    <td>Memory</td>
+                    <td>{groupContext.resourceStatus.memUsage} GB</td>
+                    <td>{groupContext.quotaMemory == null ? '∞' : `${groupContext.quotaMemory} GB`} </td>
+                  </tr>
+                  <tr>
+                    <td>GPU</td>
+                    <td>{groupContext.resourceStatus.gpuUsage} </td>
+                    <td>{groupContext.quotaGpu == null ? '∞' : groupContext.quotaGpu}</td>
+                  </tr>
+                </tbody>
+              </Table>
+            </Card>
+            <Card style={{overflow: 'auto'}}>
+              <h3>Datasets</h3>
+              {
+                groupContext.datasets.length ? (
+                <ul>
+                  {
+                    groupContext.datasets.map(dataset =>(<li>{dataset.displayName}</li>))
+                  }
+                </ul>
+                ) : (
+                  <div> No available dataset </div>
+                )
+              }
+            </Card>
+        </>
+      );
+    }
+    return <Card>Somthing Wrong.</Card>
   }
 }

--- a/packages/client/src/ee/components/shared/resourceMonitor.tsx
+++ b/packages/client/src/ee/components/shared/resourceMonitor.tsx
@@ -129,6 +129,6 @@ export default class ResrouceMonitor extends React.Component<Props, State> {
         </>
       );
     }
-    return <Card style={{overflow: 'auto'}}><Spin></Spin></Card>
+    return <Card loading={true} style={{overflow: 'auto'}}></Card>
   }
 }

--- a/packages/client/src/ee/containers/deploymentCreatePage.tsx
+++ b/packages/client/src/ee/containers/deploymentCreatePage.tsx
@@ -108,7 +108,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
           breadcrumb={<DeploymentBreadcrumb />}
           title={"Create Deployment"}
         />
-        <div style={{margin: '16px 64px'}}>
+        <div style={{margin: '16px'}}>
           <DeploymentCreateForm
             groupContext={groupContext}
             onSelectGroup={this.onChangeGroup}

--- a/packages/client/src/ee/containers/deploymentCreatePage.tsx
+++ b/packages/client/src/ee/containers/deploymentCreatePage.tsx
@@ -111,6 +111,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
         <div style={{margin: '16px'}}>
           <DeploymentCreateForm
             groupContext={groupContext}
+            refetchGroup={getGroups.refetch}
             onSelectGroup={this.onChangeGroup}
             selectedGroup={selectedGroup}
             groups={sortItems(groups)}

--- a/packages/client/src/ee/containers/deploymentEditPage.tsx
+++ b/packages/client/src/ee/containers/deploymentEditPage.tsx
@@ -119,7 +119,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
           title={`Update Deployment`}
           breadcrumb={<DeploymentBreadcrumb deploymentName={get(getPhDeployment, 'phDeployment.name')} />}
         />
-        <div style={{margin: '16px 32px'}}>
+        <div style={{margin: '16px'}}>
           <DeploymentCreateForm
             type="edit"
             initialValue={{

--- a/packages/client/src/ee/containers/deploymentEditPage.tsx
+++ b/packages/client/src/ee/containers/deploymentEditPage.tsx
@@ -13,6 +13,7 @@ import DeploymentBreadcrumb from 'ee/components/modelDeployment/breadcrumb';
 import {PhDeploymentFragment} from 'ee/components/modelDeployment/common';
 import {GET_PH_DEPLOYMENT, getMessage} from 'ee/containers/deploymentDetail';
 import {GET_MY_GROUPS} from './deploymentCreatePage';
+import { GroupContextComponentProps, withGroupContext } from 'context/group';
 
 export const UPDATE_DEPLOYMENT = gql`
   mutation updatePhDeployment($where: PhDeploymentWhereUniqueInput!, $data: PhDeploymentUpdateInput!) {
@@ -94,7 +95,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
   }
 
   render() {
-    const {getGroups, updatePhDeploymentResult, history, getPhDeployment} = this.props;
+    const {getGroups, updatePhDeploymentResult, history, getPhDeployment, groupContext} = this.props;
     if (getPhDeployment.loading) return null;
     if (getPhDeployment.error) {
       return getMessage(getPhDeployment.error)
@@ -128,6 +129,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
             }}
             selectedGroup={selectedGroup}
             groups={sortItems(groups)}
+            groupContext={groupContext}
             instanceTypes={sortItems(instanceTypes)}
             onSubmit={this.onSubmit}
             onCancel={this.onCancel}
@@ -141,6 +143,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
 
 export default compose(
   withRouter,
+  withGroupContext,
   graphql(GET_MY_GROUPS, {
     name: 'getGroups'
   }),

--- a/packages/client/src/ee/containers/deploymentEditPage.tsx
+++ b/packages/client/src/ee/containers/deploymentEditPage.tsx
@@ -95,7 +95,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
   }
 
   render() {
-    const {getGroups, updatePhDeploymentResult, history, getPhDeployment, groupContext} = this.props;
+    const {getGroups, updatePhDeploymentResult, history, getPhDeployment, groupContext, refetchGroup} = this.props;
     if (getPhDeployment.loading) return null;
     if (getPhDeployment.error) {
       return getMessage(getPhDeployment.error)
@@ -130,6 +130,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
             selectedGroup={selectedGroup}
             groups={sortItems(groups)}
             groupContext={groupContext}
+            refetchGroup={getGroups.refetch}
             instanceTypes={sortItems(instanceTypes)}
             onSubmit={this.onSubmit}
             onCancel={this.onCancel}

--- a/packages/client/src/ee/containers/jobCreatePage.tsx
+++ b/packages/client/src/ee/containers/jobCreatePage.tsx
@@ -134,6 +134,7 @@ class JobCreatePage extends React.Component<Props, State> {
             </Row>
           ) : (
             <JobCreateForm
+              showResources={true}
               refetchGroup={getGroups.refetch}
               groupContext={groupContext}
               initialValue={defaultValue}

--- a/packages/client/src/ee/containers/jobCreatePage.tsx
+++ b/packages/client/src/ee/containers/jobCreatePage.tsx
@@ -134,10 +134,11 @@ class JobCreatePage extends React.Component<Props, State> {
             </Row>
           ) : (
             <JobCreateForm
+              refetchGroup={getGroups.refetch}
               groupContext={groupContext}
               initialValue={defaultValue}
-              onSelectGroup={this.onChangeGroup}
               selectedGroup={selectedGroup}
+              onSelectGroup={this.onChangeGroup}
               groups={sortItems(groups)}
               instanceTypes={sortItems(instanceTypes)}
               images={sortItems(images)}

--- a/packages/client/src/ee/modelDeployment.tsx
+++ b/packages/client/src/ee/modelDeployment.tsx
@@ -29,7 +29,7 @@ const HEADER_HEIGHT = 64;
 
 const Content = styled(Layout.Content)`
   margin-top: ${HEADER_HEIGHT}px;
-  padding: 64px;
+  padding: 24px;
   min-height: calc(100vh - 64px);
 `;
 

--- a/packages/graphql-server/src/graphql/group.graphql
+++ b/packages/graphql-server/src/graphql/group.graphql
@@ -3,6 +3,7 @@
 # import InstanceType from "instanceType.graphql"
 # import Image from "image.graphql"
 # import Dataset from "dataset.graphql"
+# import ResourceStatus from "resourceStatus.graphql"
 
 type Group {
   id: ID!
@@ -19,6 +20,7 @@ type Group {
   instanceTypes: [InstanceType]
   images: [Image]
   datasets: [Dataset]
+  resourceStatus: ResourceStatus
   # for relation with dataset
   writable: Boolean
   # shared volume

--- a/packages/graphql-server/src/graphql/resourceStatus.graphql
+++ b/packages/graphql-server/src/graphql/resourceStatus.graphql
@@ -1,0 +1,6 @@
+type ResourceStatus {
+  groupId: String
+  cpuUsage: String
+  memUsage: String
+  gpuUsage: String
+}

--- a/packages/graphql-server/src/logger.ts
+++ b/packages/graphql-server/src/logger.ts
@@ -26,7 +26,8 @@ export enum components {
   phJob = 'PhJob',
   phDeployment = 'PhDeployment',
   internal = 'Internal',
-  usageReport = 'UsageReport'
+  usageReport = 'UsageReport',
+  resourceStatus = 'ResourceStatus'
 }
 
 export const log = (levelType: level = level.info, payload?: any) => {

--- a/packages/graphql-server/src/resolvers/group.ts
+++ b/packages/graphql-server/src/resolvers/group.ts
@@ -13,6 +13,7 @@ import { pick, isNil, omit, get, isEmpty, mapValues } from 'lodash';
 import { crd as instanceTypeResolver } from './instanceType';
 import { crd as datasetResolver } from './dataset';
 import { crd as imageResolver } from './image';
+import * as resourceStatusResolver from './resourceStatus';
 import { Context } from './interface';
 import { Attributes, FieldType } from './attr';
 import { keycloakMaxCount } from './constant';
@@ -414,7 +415,7 @@ export const typeResolvers = {
       return [];
     }
   },
-
+  resourceStatus: resourceStatusResolver.query,
   ...instanceTypeResolver.resolveInGroup(),
   ...datasetResolver.resolveInGroup(),
   ...imageResolver.resolveInGroup()

--- a/packages/graphql-server/src/resolvers/resourceStatus.ts
+++ b/packages/graphql-server/src/resolvers/resourceStatus.ts
@@ -1,0 +1,71 @@
+import { Context } from './interface';
+import { client as kubeClient } from '../crdClient/crdClientImpl';
+import * as logger from '../logger';
+const GiB = Math.pow(1024, 3);
+const MiB = Math.pow(1024, 2);
+const KiB = 1024;
+
+const converCpuValueToFloat = (value = '0') => {
+  const regex = /\d+m$/;
+  if (regex.test(value)) {
+    return parseFloat(value.replace('m', ''))/1000
+  } else {
+    return parseFloat(value);
+  }
+}
+
+const converMemResourceToBytes = (mem = '0') => {
+  const regexGiB = /\d+Gi?$/
+  const regexMiB = /\d+Mi?$/
+  const regexKiB = /\d+(K|k)i?$/
+
+  if (regexGiB.test(mem)) {
+    return parseFloat(mem.replace('Gi?$', '')) * GiB;
+  }
+  if (regexMiB.test(mem)) {
+    return parseFloat(mem.replace(/Mi?$/, '')) * MiB;
+  }
+  if (regexKiB.test(mem)) {
+    return parseFloat(mem.replace(/(K|k)i?$/, '')) * KiB;
+  }
+  return parseFloat(mem);
+}
+
+const labelStringify = (labels: Record<string, string>) => {
+  return Object.keys(labels).map(labelKey => {
+    const labelValue = labels[labelKey];
+    return `${labelKey}=${labelValue}`;
+  }).join(',');
+};
+
+export const query = async (group, args, context: Context) => {
+  const fieldSelector = labelStringify({
+    'status.phase': 'Running'
+  });
+  const labelSelector = labelStringify({
+    'primehub.io/group': `escaped-${group.name}`,
+  });
+  const {body: {items}} = await kubeClient.api.v1.namespaces(context.crdNamespace).pods.get({
+    qs: {labelSelector, fieldSelector}
+  });
+  const resourceUsing = (items || []).reduce((acc, current) => {
+    (current.spec.containers || []).forEach(container => {
+      acc.cpuUsage += converCpuValueToFloat(container.resources.requests['cpu']);
+      acc.gpuUsage += converCpuValueToFloat(container.resources.requests['nvidia.com/gpu']);
+      acc.memUsage += converMemResourceToBytes(container.resources.requests['memory']);
+    });
+    return acc;
+  }, {
+    cpuUsage: 0,
+    memUsage: 0,
+    gpuUsage: 0
+  });
+
+  // Convert memUsage to GiB
+  resourceUsing.memUsage = (Math.round(resourceUsing.memUsage / GiB * 10) / 10).toFixed(1);
+
+  return {
+    groupId: group.id,
+    ...resourceUsing
+  };
+};

--- a/packages/graphql-server/src/resolvers/resourceStatus.ts
+++ b/packages/graphql-server/src/resolvers/resourceStatus.ts
@@ -8,16 +8,16 @@ const KiB = 1024;
 const converCpuValueToFloat = (value = '0') => {
   const regex = /\d+m$/;
   if (regex.test(value)) {
-    return parseFloat(value.replace('m', ''))/1000
+    return parseFloat(value.replace('m', '')) / 1000;
   } else {
     return parseFloat(value);
   }
-}
+};
 
 const converMemResourceToBytes = (mem = '0') => {
-  const regexGiB = /\d+Gi?$/
-  const regexMiB = /\d+Mi?$/
-  const regexKiB = /\d+(K|k)i?$/
+  const regexGiB = /\d+Gi?$/;
+  const regexMiB = /\d+Mi?$/;
+  const regexKiB = /\d+(K|k)i?$/;
 
   if (regexGiB.test(mem)) {
     return parseFloat(mem.replace('Gi?$', '')) * GiB;
@@ -29,7 +29,7 @@ const converMemResourceToBytes = (mem = '0') => {
     return parseFloat(mem.replace(/(K|k)i?$/, '')) * KiB;
   }
   return parseFloat(mem);
-}
+};
 
 const labelStringify = (labels: Record<string, string>) => {
   return Object.keys(labels).map(labelKey => {
@@ -50,9 +50,9 @@ export const query = async (group, args, context: Context) => {
   });
   const resourceUsing = (items || []).reduce((acc, current) => {
     (current.spec.containers || []).forEach(container => {
-      acc.cpuUsage += converCpuValueToFloat(container.resources.requests['cpu']);
+      acc.cpuUsage += converCpuValueToFloat(container.resources.requests.cpu);
       acc.gpuUsage += converCpuValueToFloat(container.resources.requests['nvidia.com/gpu']);
-      acc.memUsage += converMemResourceToBytes(container.resources.requests['memory']);
+      acc.memUsage += converMemResourceToBytes(container.resources.requests.memory);
     });
     return acc;
   }, {

--- a/packages/graphql-server/src/resolvers/resourceStatus.ts
+++ b/packages/graphql-server/src/resolvers/resourceStatus.ts
@@ -17,8 +17,8 @@ const converCpuValueToFloat = (value = '0') => {
 const escapedGroupName = (groupName = '') => {
   let result = groupName.toLowerCase();
   result = escape(result);
-  return result.replace(/-/g,'-2d');
-}
+  return result.replace(/-/g, '-2d');
+};
 
 const converMemResourceToBytes = (mem = '0') => {
   const regexGiB = /\d+Gi?$/;
@@ -52,7 +52,7 @@ export const query = async (group, args, context: Context) => {
     component: logger.components.resourceStatus,
     type: 'QUERY',
     message: 'Query using resources of group',
-    groupName: groupName
+    groupName
   });
   const labelSelector = labelStringify({
     'primehub.io/group': `escaped-${groupName}`,

--- a/packages/graphql-server/src/resolvers/resourceStatus.ts
+++ b/packages/graphql-server/src/resolvers/resourceStatus.ts
@@ -61,6 +61,13 @@ export const query = async (group, args, context: Context) => {
     qs: {labelSelector}
   });
   const resourceUsing = (items || []).reduce((acc, current) => {
+    logger.info({
+      component: logger.components.resourceStatus,
+      type: 'REDUCE',
+      message: 'Checkinng status phase:',
+      groupName,
+      phase: current.status.phase
+    });
     if (current.status.phase === PENDING || current.status.phase === RUNNING) {
       (current.spec.containers || []).forEach(container => {
         acc.cpuUsage += converCpuValueToFloat(container.resources.requests.cpu);


### PR DESCRIPTION
### New feature: Resource using info card (ch12298 and ch10724)
### What's new
- Add ResourceStatus type in graphql.
- Add property `resourceStatus` on `Group` type.
- Add new component `ResourceMonitor`.
- Attach `ResourceMonitor` on `job/createForm` and `modelDeployment/createForm`.
- Small UI tweak for consistenly.

### We don't need
- User's resource usage.

test image tag: ~`ch12332-603b4893` `ch12332-61bc61ba`~ 🆕 `ch12332-2e71e27b`

### Screenshots
#### Creating Job
<img width="1265" alt="Screen Shot 2020-09-21 at 5 20 56 AM" src="https://user-images.githubusercontent.com/935988/93723343-62592480-fbd0-11ea-9234-793f6361cc57.png">
<img width="1265" alt="Screen Shot 2020-09-21 at 5 19 51 AM" src="https://user-images.githubusercontent.com/935988/93723320-3b025780-fbd0-11ea-85a1-bd450a13e565.png">

#### Creating Deployment
<img width="1095" alt="Screen Shot 2020-09-21 at 11 46 05 AM" src="https://user-images.githubusercontent.com/935988/93731548-10c88e00-fc00-11ea-907b-d4dacc3a1a73.png">
