### PR TITLE
Refine error messages

### DIFF
--- a/packages/graphql-server/src/crdClient/customResource.ts
+++ b/packages/graphql-server/src/crdClient/customResource.ts
@@ -1,7 +1,7 @@
 import { Watch } from '@kubernetes/client-node';
 import { pick } from 'lodash';
 import * as logger from '../logger';
-import { apiUnavailable } from '../k8sResource/k8sError';
+import { apiUnavailable, resourceNotFound } from '../k8sResource/k8sError';
 
 export interface Metadata {
   clusterName?: string;
@@ -59,6 +59,10 @@ export default class CustomResource<SpecType = any, StatusType = any> {
         name,
         error
       });
+      const CODE = 'code';
+      if (error[CODE] && error[CODE] === 404) {
+        throw resourceNotFound(error);
+      }
       throw apiUnavailable();
     }
   }

--- a/packages/graphql-server/src/k8sResource/k8sError.ts
+++ b/packages/graphql-server/src/k8sResource/k8sError.ts
@@ -2,9 +2,14 @@ import Boom from 'boom';
 import { get } from 'lodash';
 
 const API_UNAVAILABLE = 'API_UNAVAILABLE';
+const RESOURCE_NOT_FOUND = 'RESOURCE_NOT_FOUND';
 
 export const apiUnavailable = () => {
   return Boom.internal(API_UNAVAILABLE, {code: API_UNAVAILABLE});
+};
+
+export const resourceNotFound = (err: Error) => {
+  return Boom.badRequest(err.message, {code: RESOURCE_NOT_FOUND});
 };
 
 export const isErrorApiUnavailable = (error: any) => {


### PR DESCRIPTION
show object not found messages, for example:

```json
{
  "errors": [
    {
      "message": "instancetypes.primehub.io \"cpu-1243\" not found",
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR"
      }
    }
  ],
  "data": null
}
```