### PR TITLE
[Feature] add npm script to launch graphql by nodemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "type": "git",
     "url": "git+https://github.com/Canner/infuseai-canner.git"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "InfuseAI",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Canner/infuseai-canner/issues"
   },
@@ -29,8 +29,6 @@
     "**/**/websocket-extensions": "^0.1.4",
     "**/**/canner": "2.1.7"
   },
-  "author": "InfuseAI",
-  "license": "Apache-2.0",
   "licenses": [
     {
       "type": "Apache-2.0",

--- a/packages/admin-server/src/oidc/token.ts
+++ b/packages/admin-server/src/oidc/token.ts
@@ -12,9 +12,9 @@ export default class Token {
     if (token) {
       try {
         const parts = token.split('.');
-        this.header = JSON.parse(new Buffer(parts[0], 'base64').toString());
-        this.content = JSON.parse(new Buffer(parts[1], 'base64').toString());
-        this.signature = new Buffer(parts[2], 'base64');
+        this.header = JSON.parse(Buffer.from(parts[0], 'base64').toString());
+        this.content = JSON.parse(Buffer.from(parts[1], 'base64').toString());
+        this.signature = Buffer.from(parts[2], 'base64');
         this.signed = parts[0] + '.' + parts[1];
       } catch (err) {
         this.content = {

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -4,6 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "dev": "NODE_ENV=development nodemon src/ee/bin/www.ts",
+    "dev:ce": "NODE_ENV=development nodemon src/ce/bin/www.ts",
+    "debug": "NODE_ENV=development nodemon --inspect=9229 -e ts,tsx --exec node -r ts-node/register src/ee/bin/www.ts",
+    "debug:ce": "NODE_ENV=development nodemon --inspect=9229 -e ts,tsx --exec node -r ts-node/register src/ce/bin/www.ts",
     "start": "NODE_ENV=development ts-node src/ee/bin/www.ts",
     "start:lib": "NODE_ENV=development node lib/ee/bin/www",
     "start:prod": "NODE_ENV=production node lib/ee/bin/www",

--- a/packages/graphql-server/src/k8sResource/k8sSecret.ts
+++ b/packages/graphql-server/src/k8sResource/k8sSecret.ts
@@ -208,9 +208,9 @@ export default class K8sSecret {
 
   private decodeDockerConfig = (dockerconfigjson: string) => {
     try {
-      const obj = JSON.parse(new Buffer(dockerconfigjson, 'base64').toString('utf8'));
+      const obj = JSON.parse(Buffer.from(dockerconfigjson, 'base64').toString('utf8'));
       const registryHost = Object.keys(obj.auths)[0];
-      const auth = new Buffer(obj.auths[registryHost].auth, 'base64').toString('utf8');
+      const auth = Buffer.from(obj.auths[registryHost].auth, 'base64').toString('utf8');
       const authSplit = auth.split(':');
       const username = authSplit[0];
       const password = authSplit.slice(1).join(':');

--- a/packages/graphql-server/src/oidc/token.ts
+++ b/packages/graphql-server/src/oidc/token.ts
@@ -12,9 +12,9 @@ export default class Token {
     if (token) {
       try {
         const parts = token.split('.');
-        this.header = JSON.parse(new Buffer(parts[0], 'base64').toString());
-        this.content = JSON.parse(new Buffer(parts[1], 'base64').toString());
-        this.signature = new Buffer(parts[2], 'base64');
+        this.header = JSON.parse(Buffer.from(parts[0], 'base64').toString());
+        this.content = JSON.parse(Buffer.from(parts[1], 'base64').toString());
+        this.signature = Buffer.from(parts[2], 'base64');
         this.signed = parts[0] + '.' + parts[1];
       } catch (err) {
         this.content = {


### PR DESCRIPTION
- Fix node warring to replace all `new Buffer()` by `Buffer.from()`
- Add npm script to launch graphql by nodemon

Signed-off-by: Kent Huang <kentwelcome@gmail.com>