### PR TITLE
fix temporary empty page when back to user portal

### DIFF
--- a/packages/client/src/cms.tsx
+++ b/packages/client/src/cms.tsx
@@ -359,8 +359,9 @@ export default class CMSPage extends React.Component<Props, State> {
     } else if (key === 'workspace') {
       const defaultWorkspaceId = (workspaceList.find(ws => ws.isDefault) || {}).id || 'default';
       history.push(`${(window as any).APP_PREFIX}cms/${defaultWorkspaceId}/${key}`);
-    } else if (dict['en'][`${key}.externalLink`]) {
-      // add this condition to keep page content not change when opening external link
+    } else if (dict['en'][`${key}.externalLink`] || key === 'backToUserPortal') {
+      // add this condition to keep page content not change when 
+      // opening external link or backing to user portal
     } else {
       history.push(`${(window as any).APP_PREFIX}cms/${workspaceId}/${key}`);
     }
@@ -372,7 +373,7 @@ export default class CMSPage extends React.Component<Props, State> {
     const {activeKey, workspaceId} = match.params as any;
     const currentWorkspace = workspaceList.find(ws => ws.id === workspaceId) || {};
     const navigationMenu = (
-      <Menu.Item>
+      <Menu.Item key="backToUserPortal">
         <a href='/'>
           <Icon type="left"/>
           Back to User Portal


### PR DESCRIPTION
Signed-off-by: ericy <ericy@infuseai.io>

### Summary of Issue 
When clicking on 'Back to User Portal', it will temporarily direct to the empty page
<img width="1278" alt="螢幕快照 2020-10-07 上午10 47 26" src="https://user-images.githubusercontent.com/16533561/95281965-f42c8700-088a-11eb-99f3-c36c9c2dc52d.png">

### Test Image
ch12330-4ab5726
