### PR TITLE
Feature/ch12303/implement the artifact retention

### DIFF
--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -175,6 +175,7 @@ const eeResolvers = {
     createPhJob: phJob.create,
     rerunPhJob: phJob.rerun,
     cancelPhJob: phJob.cancel,
+    cleanupPhJobArtifact: phJob.artifactCleanUp,
     createPhSchedule: phSchedule.create,
     updatePhSchedule: phSchedule.update,
     deletePhSchedule: phSchedule.destroy,

--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -42,6 +42,7 @@ import { OidcTokenVerifier } from '../oidc/oidcTokenVerifier';
 import cors from '@koa/cors';
 import { JobLogCtrl } from './controllers/jobLogCtrl';
 import { PhJobCacheList } from './crdClient/phJobCacheList';
+import JobArtifactCleaner from './utils/jobArtifactCleaner';
 
 // cache
 import {
@@ -315,6 +316,12 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
     appPrefix: config.appPrefix,
     persistLog,
   });
+
+  // job artifact cleaner
+  if (config.enableStore) {
+    const jobArtifactCleaner = new JobArtifactCleaner(mClient, storeBucket);
+    jobArtifactCleaner.start();
+  }
 
   // ann
   const annCtrl = new AnnCtrl({

--- a/packages/graphql-server/src/ee/graphql/ee.graphql
+++ b/packages/graphql-server/src/ee/graphql/ee.graphql
@@ -1,4 +1,4 @@
-# import BuildImageJob, BuildImageOrderByInput, BuildImageJobConnection, BuildImageJobWhereInput, BuildImageJobWhereUniqueInput, BuildImage, BuildImageConnection, BuildImageWhereUniqueInput, BuildImageWhereInput, BuildImageCreateInput, BuildImageUpdateInput from "./buildImage.graphql" 
+# import BuildImageJob, BuildImageOrderByInput, BuildImageJobConnection, BuildImageJobWhereInput, BuildImageJobWhereUniqueInput, BuildImage, BuildImageConnection, BuildImageWhereUniqueInput, BuildImageWhereInput, BuildImageCreateInput, BuildImageUpdateInput from "./buildImage.graphql"
 # import PhJob, PhJobOrderByInput, PhJobConnection, PhJobWhereUniqueInput, PhJobWhereInput, PhJobCreateInput, PhJobCancelResponse from "./phJob.graphql"
 # import PhSchedule, PhScheduleOrderByInput, PhScheduleConnection, PhScheduleWhereUniqueInput, PhScheduleWhereInput, PhScheduleCreateInput, PhScheduleUpdateInput, PhScheduleDeleteResponse, PhScheduleRunResponse from "./phSchedule.graphql"
 # import PhDeployment, PhDeploymentConnection, PhDeploymentWhereUniqueInput, PhDeploymentWhereInput, PhDeploymentCreateInput, PhDeploymentUpdateInput, PhDeploymentClientCreateInput, PhDeploymentClientCreateResponse, PhDeploymentClientWhereUniqueInput from "./phDeployment.graphql"
@@ -137,6 +137,7 @@ type Mutation {
   createPhJob(data: PhJobCreateInput!): PhJob!
   rerunPhJob(where: PhJobWhereUniqueInput!): PhJob!
   cancelPhJob(where: PhJobWhereUniqueInput!): PhJobCancelResponse!
+  cleanupPhJobArtifact: Int
 
   """PhSchedule"""
   createPhSchedule(data: PhScheduleCreateInput!): PhSchedule!

--- a/packages/graphql-server/src/ee/resolvers/phJob.ts
+++ b/packages/graphql-server/src/ee/resolvers/phJob.ts
@@ -206,8 +206,12 @@ export const typeResolvers = {
       const list: any[] = [];
       const stream = minioClient.listObjects(storeBucket, prefix, true);
       stream.on('data', (obj: BucketItem) => {
+        const name = obj.name.substring(prefix.length + 1);
+        if (name.startsWith('.metadata/')) {
+          return;
+        }
         list.push({
-          name: obj.name.substring(prefix.length + 1),
+          name,
           size: obj.size,
           lastModified: obj.lastModified.toISOString(),
         });

--- a/packages/graphql-server/src/ee/resolvers/phJob.ts
+++ b/packages/graphql-server/src/ee/resolvers/phJob.ts
@@ -15,6 +15,7 @@ import { keycloakMaxCount } from '../../resolvers/constant';
 import { isUserAdmin } from '../../resolvers/user';
 import { SCHEDULE_LABEL } from './phSchedule';
 import { BucketItem } from 'minio';
+import JobArtifactCleaner from '../utils/jobArtifactCleaner';
 
 const EXCEED_QUOTA_ERROR = 'EXCEED_QUOTA';
 const NOT_AUTH_ERROR = 'NOT_AUTH';
@@ -374,3 +375,11 @@ export const cancel = async (root, args, context: Context) => {
 
   return {id};
 };
+
+export const artifactCleanUp = async (root, args, context: Context) => {
+  const {minioClient, storeBucket} = context;
+
+  const cleaner = new JobArtifactCleaner(minioClient, storeBucket);
+  await cleaner.cleanUp();
+  return 0;
+}

--- a/packages/graphql-server/src/ee/resolvers/phJob.ts
+++ b/packages/graphql-server/src/ee/resolvers/phJob.ts
@@ -382,4 +382,4 @@ export const artifactCleanUp = async (root, args, context: Context) => {
   const cleaner = new JobArtifactCleaner(minioClient, storeBucket);
   await cleaner.cleanUp();
   return 0;
-}
+};

--- a/packages/graphql-server/src/ee/utils/jobArtifactCleaner.ts
+++ b/packages/graphql-server/src/ee/utils/jobArtifactCleaner.ts
@@ -1,0 +1,96 @@
+import { Client as MinioClient, BucketItem} from 'minio';
+import * as logger from '../../logger';
+import { Stream } from 'stream';
+import getStream from 'get-stream';
+
+const getStringFromStream = (stream) => {
+
+}
+
+export default class JobArtifactCleaner {
+  private minioClient: MinioClient;
+  private bucket: string;
+
+  constructor(minioClient: MinioClient, bucket: string) {
+    this.minioClient = minioClient;
+    this.bucket = bucket;
+  }
+
+  public cleanUp = async () => {
+    logger.info({type: 'JOB_ARTIFACT_CLEANUP_START'});
+
+    // const prefix = `groups/${groupName}/jobArtifacts/${phjobID}`;
+
+    const groups = await this.listGroup();
+    groups.forEach(group => {
+      this.cleanArtifactsByGroup(group);
+    });
+
+    try {
+      logger.info({type: 'JOB_ARTIFACT_CLEANUP_COMPLETED'});
+    } catch (e) {
+      logger.error({type: 'JOB_ARTIFACT_CLEANUP_FAILED'});
+    }
+  }
+
+  private listGroup = async (): Promise<string[]> => {
+    const prefix = `groups/`;
+    const groups = [];
+    return new Promise<string[]> ((resolve, reject) => {
+      const stream = this.minioClient.listObjects(this.bucket, prefix, false);
+      stream.on('data', (obj: BucketItem) => {
+        const group = obj.prefix.split('/')[1];
+        groups.push(group);
+      });
+      stream.on('error', (error: Error) => {
+        reject(error);
+      });
+      stream.on('end', () => {
+        resolve(groups);
+      });
+    });
+  }
+
+  private cleanArtifactsByGroup = async group => {
+    const prefix = `groups/${group}/jobArtifacts/`;
+    const promises = [];
+    await new Promise<string[]> ((resolve, reject) => {
+      const stream = this.minioClient.listObjects(this.bucket, prefix, false);
+      stream.on('data', async (obj: BucketItem) => {
+        const job = obj.prefix.split('/')[3];
+        promises.push(this.cleanArtifact(obj));
+      });
+      stream.on('error', (error: Error) => {
+        reject(error);
+      });
+      stream.on('end', () => {
+        resolve();
+      });
+    });
+
+    return Promise.all(promises);
+  }
+
+  private cleanArtifact = async jobObj => {
+    const job = jobObj.prefix.split('/')[3];
+    const expiredAt = await this.getExpiredAt(jobObj.prefix);
+
+    if ( expiredAt && expiredAt < Date.now() / 1000) {
+      logger.info({job, expiredAt, delete: 'true'});
+    } else {
+      logger.info({job, expiredAt});
+    }
+  }
+
+  private getExpiredAt = async (jobPrefix): Promise<number> => {
+    const expiredAtFile = `${jobPrefix}.metadata/expiredAt`;
+    try {
+      const stream: Stream = await this.minioClient.getObject(this.bucket, expiredAtFile);
+      const result = await getStream(stream);
+      return Number(result);
+    } catch (e) {
+      // file not found
+      return 0;
+    }
+  }
+}

--- a/packages/watcher/Dockerfile
+++ b/packages/watcher/Dockerfile
@@ -8,9 +8,9 @@ COPY lerna.json package.json tsconfig.json tslint.json yarn.lock ./
 COPY packages/graphql-server packages/graphql-server
 COPY packages/watcher packages/watcher
 
-RUN npx lerna bootstrap --scope=@infuseai/watcher
-
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+RUN npx lerna bootstrap --scope=@infuseai/watcher
 
 RUN cd packages/graphql-server \
   && npm run build:prod \


### PR DESCRIPTION
# Introduction
https://app.clubhouse.io/infuseai/story/12303/implement-the-artifact-retention

# Note
1. It will cleanup the artifacts everyday (in graphql)
1. It will only enabled if primehub store is enabled.
1. In graphql it provide a new endpoint to trigger artifact cleanup 

    ```
    mutation {
      cleanupPhJobArtifact
    }
   ```

1. In graphql artifact API, it will not return files under `.metadata`.

# Image
~~ch12303-5993892~~
ch12303-5adc934: logs for cleaning group