### PR TITLE
Implement the notebook page with log

### DIFF
--- a/packages/client/src/components/pageBody.tsx
+++ b/packages/client/src/components/pageBody.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 
-export default class PageBody extends React.Component {
+type Props = {
+  style?: React.CSSProperties;
+};
+export default class PageBody extends React.Component<Props> {
   render() {
-    const {children} = this.props;
+    const {
+      children,
+      style={}
+    } = this.props;
     return (
       <div style={{
         margin: '16px',
         padding: '16px',
         background: '#fff',
+        ...style,
       }}>
         {children}
       </div>

--- a/packages/client/src/components/pageTitle.tsx
+++ b/packages/client/src/components/pageTitle.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 type Props = {
   breadcrumb: React.ReactNode;
   title: React.ReactNode;
-  style?: Object;
+  style?: React.CSSProperties;
 };
 
 export default class PageTitle extends React.Component<Props> {
@@ -25,7 +25,9 @@ export default class PageTitle extends React.Component<Props> {
         }}>
           {breadcrumb}
         </div>
-        <h2>{title}</h2>
+        {
+          title ?  <h2>{title}</h2> : <></>
+        }
       </div>
     )
   }

--- a/packages/client/src/components/share/log.tsx
+++ b/packages/client/src/components/share/log.tsx
@@ -132,7 +132,7 @@ export default class Logs extends React.Component<Props, State> {
     // Fetch the log
     while (true) {
       try {
-        res = await fetch(`${endpoint}?tailLines=${tailLines}`, {
+        res = await fetch(`${endpoint}?tailLines=${tailLines}&follow=true`, {
           signal,
           method: 'GET',
           headers: {

--- a/packages/client/src/containers/jupyterhubPage.tsx
+++ b/packages/client/src/containers/jupyterhubPage.tsx
@@ -27,7 +27,7 @@ class JupyterhubContainer extends React.Component<Props> {
           <a href={`${basename}`}><Icon type="home" /></a>
           }
         </Breadcrumb.Item>
-        <Breadcrumb.Item key="notebook">Notebook</Breadcrumb.Item>
+        <Breadcrumb.Item key="notebook">Notebooks</Breadcrumb.Item>
       </Breadcrumb>
     );
   }
@@ -39,11 +39,11 @@ class JupyterhubContainer extends React.Component<Props> {
       <>
         <PageTitle
           breadcrumb={this.renderBreadCrumb()}
-          title={"Notebook"}
+          title={"Notebooks"}
         />
         <PageBody style={{flex: '1 1 0%'}}>
           <Tabs style={{height: '100%'}}>
-            <Tabs.TabPane key="information" tab="Information">
+            <Tabs.TabPane key="information" tab="Notebooks">
               <div style={{height: 'calc(100vh - 310px)'}}>
                 <IFrame src={`/hub/primehub/home?group=${groupContext.name}`}/>
               </div>

--- a/packages/client/src/containers/jupyterhubPage.tsx
+++ b/packages/client/src/containers/jupyterhubPage.tsx
@@ -2,21 +2,68 @@ import * as React from 'react';
 import {compose} from 'recompose';
 import { withGroupContext, GroupContextComponentProps } from 'context/group';
 import IFrame from 'components/hub/iframe';
+import PageTitle from 'components/pageTitle';
+import Log from 'components/share/log';
+import PageBody from 'components/pageBody';
+import { Breadcrumb, Icon, Tabs } from 'antd';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import { appPrefix } from 'utils/env';
+import { withRouter } from 'react-router';
 
-type Props = GroupContextComponentProps;
+type Props = GroupContextComponentProps & RouteComponentProps;
 
 class JupyterhubContainer extends React.Component<Props> {
+  renderBreadCrumb () {
+    const { match } = this.props;
+    const params = match.params as any
+    const basename = params.groupName ? `${appPrefix}g/${params.groupName}` : `${appPrefix}`;
+
+    return (
+      <Breadcrumb style={{marginBottom: 8}}>
+        <Breadcrumb.Item key="home">
+          {
+          params.groupName ?
+          <Link to={`${basename}`}><Icon type="home" /></Link> :
+          <a href={`${basename}`}><Icon type="home" /></a>
+          }
+        </Breadcrumb.Item>
+        <Breadcrumb.Item key="notebook">Notebook</Breadcrumb.Item>
+      </Breadcrumb>
+    );
+  }
+
   render() {
     const {groupContext} = this.props;
 
     return (
-      groupContext && groupContext.name ?
-      <IFrame src={`/hub/primehub/home?group=${groupContext.name}`} /> :
-      <div />
+      <>
+        <PageTitle
+          breadcrumb={this.renderBreadCrumb()}
+          title={"Notebook"}
+        />
+        <PageBody style={{flex: '1 1 0%'}}>
+          <Tabs style={{height: '100%'}}>
+            <Tabs.TabPane key="information" tab="Information">
+              <div style={{height: 'calc(100vh - 310px)'}}>
+                <IFrame src={`/hub/primehub/home?group=${groupContext.name}`}/>
+              </div>
+            </Tabs.TabPane>
+            <Tabs.TabPane
+              key="logs"
+              tab="Logs"
+            >
+              <Log
+                endpoint='/api/logs/jupyterhub'
+              />
+            </Tabs.TabPane>
+          </Tabs>
+        </PageBody>
+      </>
     );
   }
 }
 
 export default compose(
-  withGroupContext
+  withGroupContext,
+  withRouter
 )(JupyterhubContainer)

--- a/packages/graphql-server/src/app.ts
+++ b/packages/graphql-server/src/app.ts
@@ -587,7 +587,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
   mountAnn(rootRouter, annCtrl);
 
   // Notebook Log
-  rootRouter.get(podLogs.getRoute(), authenticateMiddleware, podLogs.streamPodLogs);
+  rootRouter.get(podLogs.getJupyterHubRoute(), authenticateMiddleware, podLogs.streamJupyterHubLogs);
 
   // health check
   rootRouter.get('/health', async ctx => {

--- a/packages/graphql-server/src/controllers/logCtrl.ts
+++ b/packages/graphql-server/src/controllers/logCtrl.ts
@@ -1,4 +1,3 @@
-import { client as kubeClient } from '../crdClient/crdClientImpl';
 import { ParameterizedContext } from 'koa';
 import { Stream } from 'stream';
 import * as logger from '../logger';
@@ -28,7 +27,11 @@ export class PodLogs {
           container
         } = ctx.query;
         const podName = 'jupyter-' + escapePodName(ctx.username);
-        const stream = getK8SLogStream(this.namespace, podName, {container: container || 'notebook', follow, tailLines});
+        const stream = getK8SLogStream(this.namespace, podName, {
+          container: container || 'notebook',
+          follow,
+          tailLines
+        });
         stream.on('error', err => {
           logger.error({
             component: logger.components.internal,

--- a/packages/graphql-server/src/controllers/logCtrl.ts
+++ b/packages/graphql-server/src/controllers/logCtrl.ts
@@ -23,7 +23,7 @@ export class PodLogs {
     }
 
     public streamPodLogs = async (ctx: ParameterizedContext) => {
-        const {tailLines, container} = ctx.query;
+        const {follow=true, tailLines, container} = ctx.query;
         const podName = 'jupyter-' + escapePodName(ctx.username);
 
         let tail = 1000;
@@ -35,7 +35,8 @@ export class PodLogs {
             .namespaces(this.namespace).pods(podName).log.getByteStream({
                 qs: {
                     container: container || 'notebook',
-                    tailLines: tail
+                    tailLines: tail,
+                    follow
                 }
             });
 

--- a/packages/graphql-server/src/controllers/logCtrl.ts
+++ b/packages/graphql-server/src/controllers/logCtrl.ts
@@ -1,13 +1,13 @@
-import { kubeConfig, client as kubeClient } from '../crdClient/crdClientImpl';
+import { client as kubeClient } from '../crdClient/crdClientImpl';
 import { ParameterizedContext } from 'koa';
 import { Stream } from 'stream';
 import * as logger from '../logger';
 import { escapePodName } from '../utils/escapism';
+import { getStream as getK8SLogStream } from '../utils/k8sLog';
 
 export class PodLogs {
 
     private namespace: string;
-    private kubeClient: any;
 
     constructor({
         namespace
@@ -15,44 +15,29 @@ export class PodLogs {
         namespace: string
     }) {
         this.namespace = namespace || ' default';
-        this.kubeClient = kubeClient;
     }
 
-    public getRoute = () => {
+    public getJupyterHubRoute = () => {
         return '/logs/jupyterhub';
     }
 
-    public streamPodLogs = async (ctx: ParameterizedContext) => {
+    public streamJupyterHubLogs = async (ctx: ParameterizedContext) => {
         const {
-          follow = true,
+          follow,
           tailLines,
           container
         } = ctx.query;
         const podName = 'jupyter-' + escapePodName(ctx.username);
-
-        let tail = 1000;
-        if (tailLines) {
-            tail = parseInt(tailLines, 10);
-        }
-
-        const stream: Stream = await this.kubeClient.api.v1
-            .namespaces(this.namespace).pods(podName).log.getByteStream({
-                qs: {
-                    container: container || 'notebook',
-                    tailLines: tail,
-                    follow
-                }
-            });
-
+        const stream = getK8SLogStream(this.namespace, podName, {container: container || 'notebook', follow, tailLines});
         stream.on('error', err => {
-            logger.error({
-                component: logger.components.internal,
-                type: 'K8S_STREAM_LOG',
-                message: err.message
-            });
-            ctx.res.end();
+          logger.error({
+            component: logger.components.internal,
+            type: 'K8S_STREAM_LOG',
+            message: err.message
+          });
+
+          ctx.res.end();
         });
         ctx.body = stream;
     }
-
 }

--- a/packages/graphql-server/src/controllers/logCtrl.ts
+++ b/packages/graphql-server/src/controllers/logCtrl.ts
@@ -23,7 +23,11 @@ export class PodLogs {
     }
 
     public streamPodLogs = async (ctx: ParameterizedContext) => {
-        const {follow=true, tailLines, container} = ctx.query;
+        const {
+          follow = true,
+          tailLines,
+          container
+        } = ctx.query;
         const podName = 'jupyter-' + escapePodName(ctx.username);
 
         let tail = 1000;

--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -741,7 +741,7 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
   mountAnn(rootRouter, annCtrl);
 
   // Notebook Log
-  rootRouter.get(podLogs.getRoute(), authenticateMiddleware, podLogs.streamPodLogs);
+  rootRouter.get(podLogs.getJupyterHubRoute(), authenticateMiddleware, podLogs.streamJupyterHubLogs);
 
   // Log Ctrl
   rootRouter.get(logCtrl.getRoute(),

--- a/packages/graphql-server/src/ee/controllers/jobLogCtrl.ts
+++ b/packages/graphql-server/src/ee/controllers/jobLogCtrl.ts
@@ -1,17 +1,14 @@
-import Router from 'koa-router';
 import CrdClientImpl, { kubeConfig, client as kubeClient } from '../../crdClient/crdClientImpl';
 import { ParameterizedContext } from 'koa';
 import { Stream } from 'stream';
-import { get } from 'lodash';
 import * as logger from '../../logger';
 import PersistLog from '../../utils/persistLog';
-import request from 'request';
+import { getStream as getK8SLogStream } from '../../utils/k8sLog';
 
 const MODEL = 'model';
 
 export class JobLogCtrl {
   private namespace: string;
-  private kubeClient: any;
   private crdClient: CrdClientImpl;
   private appPrefix: string;
   private persistLog: PersistLog;
@@ -28,7 +25,6 @@ export class JobLogCtrl {
     persistLog?: PersistLog,
   }) {
     this.namespace = namespace || 'default';
-    this.kubeClient = kubeClient;
     this.crdClient = crdClient;
     this.appPrefix = appPrefix;
     this.persistLog = persistLog;
@@ -40,7 +36,7 @@ export class JobLogCtrl {
     const jobId = ctx.params.jobId;
     const job = await this.crdClient.imageSpecJobs.get(jobId);
     const podName = job.status.podName;
-    const stream = this.getStream(namespace, podName, {follow, tailLines});
+    const stream = getK8SLogStream(namespace, podName, {follow, tailLines});
 
     stream.on('error', err => {
       logger.error({
@@ -70,7 +66,7 @@ export class JobLogCtrl {
       const prefix = `logs/phjob/${jobId}`;
       stream = await this.persistLog.getStream(prefix, {tailLines: tail});
     } else {
-      stream = this.getStream(namespace, podName, {follow, tailLines});
+      stream = getK8SLogStream(namespace, podName, {follow, tailLines});
       stream.on('error', err => {
         logger.error({
           component: logger.components.internal,
@@ -88,7 +84,7 @@ export class JobLogCtrl {
     const {follow, tailLines} = ctx.query;
     const namespace = ctx.params.namespace || this.namespace;
     const podName = ctx.params.podName;
-    const stream = this.getStream(namespace, podName, {container: MODEL, follow, tailLines});
+    const stream = getK8SLogStream(namespace, podName, {container: MODEL, follow, tailLines});
     stream.on('error', err => {
       logger.error({
         component: logger.components.internal,
@@ -123,38 +119,5 @@ export class JobLogCtrl {
 
   public getPhDeploymentEndpoint = (namespace: string, podName: string) => {
     return `${this.appPrefix || ''}/logs/namespaces/${namespace}/phdeployments/${podName}`;
-  }
-
-  private getStream = (
-    namespace: string,
-    podName: string,
-    options?: {follow?: boolean, tailLines?: number, container?: string}): Stream => {
-    const container = get(options, 'container');
-    const follow = get(options, 'follow', true);
-    const tailLines = get(options, 'tailLines');
-
-    // Use the 'kubernetes@client-nodes' Log API to tail the log.
-    // Ref: https://github.com/kubernetes-client/javascript/blob/0.11.1/src/log.ts
-    const path = `/api/v1/namespaces/${namespace}/pods/${podName}/log`;
-
-    const cluster = kubeConfig.getCurrentCluster();
-    if (!cluster) {
-        throw new Error('No currently active cluster');
-    }
-    const url = cluster.server + path;
-
-    const requestOptions: request.Options = {
-        method: 'GET',
-        qs: {
-          container,
-          follow,
-          tailLines,
-        },
-        uri: url,
-    };
-
-    kubeConfig.applyToRequest(requestOptions);
-
-    return request(requestOptions);
   }
 }

--- a/packages/graphql-server/src/utils/k8sLog.ts
+++ b/packages/graphql-server/src/utils/k8sLog.ts
@@ -1,0 +1,30 @@
+import { get } from 'lodash';
+import request from 'request';
+import { kubeConfig } from '../crdClient/crdClientImpl';
+import { Stream } from 'stream';
+
+export const getStream = (
+  namespace: string,
+  podName: string,
+  options?: {follow?: boolean, tailLines?: number, container?: string}): Stream => {
+
+  // Use the 'kubernetes@client-nodes' Log API to tail the log.
+  // Ref: https://github.com/kubernetes-client/javascript/blob/0.11.1/src/log.ts
+  const path = `/api/v1/namespaces/${namespace}/pods/${podName}/log`;
+
+  const cluster = kubeConfig.getCurrentCluster();
+  if (!cluster) {
+      throw new Error('No currently active cluster');
+  }
+  const url = cluster.server + path;
+
+  const requestOptions: request.Options = {
+      method: 'GET',
+      qs: options,
+      uri: url,
+  };
+
+  kubeConfig.applyToRequest(requestOptions);
+
+  return request(requestOptions);
+};

--- a/packages/graphql-server/test/escapism-unit.spec.ts
+++ b/packages/graphql-server/test/escapism-unit.spec.ts
@@ -15,7 +15,6 @@ describe('escapeToPrimehubLabel', () => {
   });
 });
 
-
 describe('escapeToPodName', () => {
   it('should be the same with a normal username', () => {
     expect(escapePodName('foobarbar')).to.be.equals('foobarbar');
@@ -24,4 +23,4 @@ describe('escapeToPodName', () => {
   it('should be escape special chars in a username', () => {
     expect(escapePodName('foobarbar@infuseai.io')).to.be.equals('foobarbar-40infuseai-2eio');
   });
-})
+});


### PR DESCRIPTION
image: ch14200-3c6bc7a

In this pull request.
1.  Fix the bug in graphql log
2. Add log pane for notebook

## Non-scope:
Retry the log if the underlying pod is restarted.

## Screenshot
![image](https://user-images.githubusercontent.com/860633/102313885-69fc4f80-3fac-11eb-8e44-5208cae6d774.png)
![image](https://user-images.githubusercontent.com/860633/102313921-7b455c00-3fac-11eb-8c9d-1d830eaa7118.png)
