### PR TITLE
Normalize group name to group path

### DIFF
--- a/packages/graphql-server/src/ee/resolvers/phJob.ts
+++ b/packages/graphql-server/src/ee/resolvers/phJob.ts
@@ -17,6 +17,7 @@ import { SCHEDULE_LABEL } from './phSchedule';
 import { BucketItem } from 'minio';
 import JobArtifactCleaner from '../utils/jobArtifactCleaner';
 import { ErrorCodes } from '../../errorCodes';
+import { toGroupPath } from '../../utils/groupCheck';
 
 const {EXCEED_QUOTA_ERROR, NOT_AUTH_ERROR} = ErrorCodes;
 
@@ -190,7 +191,7 @@ export const typeResolvers = {
   async artifact(parent, args, context: Context) {
     const {minioClient, storeBucket} = context;
     const phjobID = parent.id;
-    const groupName = `${parent.groupName}`.toLowerCase();
+    const groupName = toGroupPath(parent.groupName);
     const prefix = `groups/${groupName}/jobArtifacts/${phjobID}`;
 
     return new Promise<any>((resolve, reject) => {
@@ -230,7 +231,7 @@ export const typeResolvers = {
   async monitoring(parent, args, context: Context) {
     const { minioClient, storeBucket } = context;
     const phjobID = parent.id;
-    const groupName = `${parent.groupName}`.toLowerCase();
+    const groupName = toGroupPath(parent.groupName);
     const objectName = `groups/${groupName}/jobArtifacts/${phjobID}/.metadata/monitoring`;
 
     return new Promise<any>((resolve, reject) => {

--- a/packages/graphql-server/src/ee/utils/jobArtifactCleaner.ts
+++ b/packages/graphql-server/src/ee/utils/jobArtifactCleaner.ts
@@ -2,6 +2,7 @@ import { Client as MinioClient, BucketItem} from 'minio';
 import * as logger from '../../logger';
 import { Stream } from 'stream';
 import getStream from 'get-stream';
+import { toGroupPath } from '../../utils/groupCheck';
 
 const CLEANUP_INTERVAL_SECONDS = 86400;
 
@@ -55,7 +56,7 @@ export default class JobArtifactCleaner {
   }
 
   private cleanArtifactsByGroup = async group => {
-    group = `${group}`.toLowerCase();
+    group = toGroupPath(group);
     const prefix = `groups/${group}/jobArtifacts/`;
     const promises = [];
     await new Promise<string[]> ((resolve, reject) => {

--- a/packages/graphql-server/src/k8sResource/k8sGroupPvc.ts
+++ b/packages/graphql-server/src/k8sResource/k8sGroupPvc.ts
@@ -1,16 +1,14 @@
 import { client as kubeClient } from '../crdClient/crdClientImpl';
 import { get, isEmpty, isUndefined, isNull } from 'lodash';
 import { ApolloError } from 'apollo-server';
+import { toGroupPath } from '../utils/groupCheck';
 
 // utils
 const stringifyVolumeSize = (volumeSize: number) => `${volumeSize}Gi`;
 const parseVolumeSize = (volumeSizeFromK8s: string) => parseFloat(volumeSizeFromK8s.replace('Gi', ''));
 
-const escapeGroupName = (groupName: string) =>
-  groupName.replace(/_/g, '-').toLowerCase();
-
 export const getPvcName = (groupName: string) => {
-  return `project-${escapeGroupName(groupName)}`;
+  return `project-${toGroupPath(groupName)}`;
 };
 
 export default class K8sGroupPvc {
@@ -55,7 +53,7 @@ export default class K8sGroupPvc {
     volumeSize: number
   }) => {
     try {
-      const escapedGroupName = escapeGroupName(groupName);
+      const escapedGroupName = toGroupPath(groupName);
       const pvcName = getPvcName(groupName);
       const {body} = await this.resource.post({
         body: {

--- a/packages/graphql-server/src/resolvers/group.ts
+++ b/packages/graphql-server/src/resolvers/group.ts
@@ -23,6 +23,7 @@ import Boom from 'boom';
 import GroupRepresentation from 'keycloak-admin/lib/defs/groupRepresentation';
 import {createConfig} from '../config';
 import { transform } from './groupUtils';
+import { isGroupNameAvailable } from '../utils/groupCheck';
 
 const config = createConfig();
 
@@ -95,11 +96,9 @@ export const create = async (root, args, context: Context) => {
   }
 
   // check existing groups with the same name
-  groups.map(g => {
-    if (payload.name.toLowerCase() === g.name.toLowerCase()) {
-      throw new ApolloError('Group exists with same name', 'GROUP_CONFLICT_NAME');
-    }
-  });
+  if (!isGroupNameAvailable(payload.name, groups)) {
+    throw new ApolloError('Group exists with same name', 'GROUP_CONFLICT_NAME');
+  }
 
   let groupId: string;
   try {

--- a/packages/graphql-server/src/utils/groupCheck.ts
+++ b/packages/graphql-server/src/utils/groupCheck.ts
@@ -1,17 +1,26 @@
+import GroupRepresentation from 'keycloak-admin/lib/defs/groupRepresentation';
 import * as logger from '../logger';
 
 export const isGroupBelongUser = async (ctx: any, userId: string, groupName: string): Promise<boolean> => {
-    const groups = await ctx.kcAdminClient.users.listGroups({
-      id: userId
-    });
-    groupName = groupName.toLowerCase();
-    const groupNames = groups.map(g => toGroupPath(g.name));
-    if (groupNames.indexOf(groupName) >= 0) { return true; }
+  const groups = await ctx.kcAdminClient.users.listGroups({
+    id: userId
+  });
+  const groupNames = groups.map(g => toGroupPath(g.name));
+  if (groupNames.indexOf(toGroupPath(groupName)) >= 0) { return true; }
 
-    // show validation input and the white list
-    logger.warn({validator: 'isGroupBelongUser', args: {group: groupName, validGroupNames: groupNames}});
-    return false;
-  };
+  // show validation input and the white list
+  logger.warn({ validator: 'isGroupBelongUser', args: { group: groupName, validGroupNames: groupNames } });
+  return false;
+};
 
 export const toGroupPath = (groupName: string) =>
   groupName.replace(/_/g, '-').toLowerCase();
+
+export const isGroupNameAvailable = (groupName: string, groupList: GroupRepresentation[]) => {
+  const groupNames = groupList.map(g => toGroupPath(g.name));
+  const available = groupNames.indexOf(toGroupPath(groupName)) === -1;
+  if (!available) {
+    logger.warn({ validator: 'isGroupNameAvailable', args: { group: groupName, existingGroupNames: groupNames } });
+  }
+  return available;
+};

--- a/packages/graphql-server/src/utils/groupCheck.ts
+++ b/packages/graphql-server/src/utils/groupCheck.ts
@@ -1,9 +1,17 @@
+import * as logger from '../logger';
+
 export const isGroupBelongUser = async (ctx: any, userId: string, groupName: string): Promise<boolean> => {
     const groups = await ctx.kcAdminClient.users.listGroups({
       id: userId
     });
     groupName = groupName.toLowerCase();
-    const groupNames = groups.map(g => g.name.toLowerCase());
+    const groupNames = groups.map(g => toGroupPath(g.name));
     if (groupNames.indexOf(groupName) >= 0) { return true; }
+
+    // show validation input and the white list
+    logger.warn({validator: 'isGroupBelongUser', args: {group: groupName, validGroupNames: groupNames}});
     return false;
   };
+
+export const toGroupPath = (groupName: string) =>
+  groupName.replace(/_/g, '-').toLowerCase();

--- a/packages/graphql-server/test/group-check-unit.spec.ts
+++ b/packages/graphql-server/test/group-check-unit.spec.ts
@@ -1,0 +1,33 @@
+import * as chai from 'chai';
+import { isGroupNameAvailable } from '../src/utils/groupCheck';
+
+const expect = chai.expect;
+const groupList = [{name: 'primehub-abc'}];
+
+describe('isGroupNameAvailable', () => {
+  it('exact same group name primehub-abc, it have to reject', () => {
+    expect(isGroupNameAvailable('primehub-abc', groupList))
+      .to.be.false;
+  });
+
+  it('any group with the empty groupList', () => {
+    expect(isGroupNameAvailable('PrimeHub_abc', []))
+      .to.be.true;
+  });
+
+  it('primehub-ABC deny by toLowerCase', () => {
+    expect(isGroupNameAvailable('primehub-ABC', groupList))
+      .to.be.false;
+  });
+
+  it('primehub_abc deny by normalization - to _', () => {
+    expect(isGroupNameAvailable('primehub_abc', groupList))
+      .to.be.false;
+  });
+
+  it('allow a non-conflict group name', () => {
+    expect(isGroupNameAvailable('infuseai', groupList))
+      .to.be.true;
+  });
+});
+


### PR DESCRIPTION
* convert a group name to a k8s resource valid name
* show group validating failed cause in the logs

```json
{
  "time": "2021-01-11T22:15:53.104Z",
  "level": "WARN",
  "validator": "isGroupBelongUser",
  "args": {
    "inputGroup": "primehub-abc",
    "validGroupNames": [
      "everyone",
      "phusers",
      "primehub-cabc"
    ]
  }
}
```