### PR TITLE
Fix shared volume with configured storageclass

### DIFF
--- a/packages/graphql-server/src/app.ts
+++ b/packages/graphql-server/src/app.ts
@@ -137,13 +137,14 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
   // dataset pvc
   const datasetPvc = new K8sDatasetPvc({
     namespace: config.k8sCrdNamespace,
-    primehubGroupSc: config.primehubGroupSc
+    primehubGroupSc: config.primehubGroupSc,
+    groupVolumeStorageClass: config.groupVolumeStorageClass,
   });
   // group pvc
   const groupPvc = new K8sGroupPvc({
     namespace: config.k8sCrdNamespace,
     primehubGroupSc: config.primehubGroupSc,
-    groupVolumeStorageClass: config.groupVolumeStorageClass
+    groupVolumeStorageClass: config.groupVolumeStorageClass,
   });
   // K8sUploadServerSecret
   const k8sUploadServerSecret = new K8sUploadServerSecret({

--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -150,13 +150,14 @@ export const createApp = async (): Promise<{app: Koa, server: ApolloServer, conf
   // dataset pvc
   const datasetPvc = new K8sDatasetPvc({
     namespace: config.k8sCrdNamespace,
-    primehubGroupSc: config.primehubGroupSc
+    primehubGroupSc: config.primehubGroupSc,
+    groupVolumeStorageClass: config.groupVolumeStorageClass,
   });
   // group pvc
   const groupPvc = new K8sGroupPvc({
     namespace: config.k8sCrdNamespace,
     primehubGroupSc: config.primehubGroupSc,
-    groupVolumeStorageClass: config.groupVolumeStorageClass
+    groupVolumeStorageClass: config.groupVolumeStorageClass,
   });
   // K8sUploadServerSecret
   const k8sUploadServerSecret = new K8sUploadServerSecret({

--- a/packages/graphql-server/src/resolvers/dataset.ts
+++ b/packages/graphql-server/src/resolvers/dataset.ts
@@ -21,7 +21,8 @@ const uploadServerList = ['pv', 'nfs', 'hostPath'];
 const config = createConfig();
 const datasetPvcQuery = new K8sDatasetPvc({
   namespace: config.k8sCrdNamespace,
-  primehubGroupSc: config.primehubGroupSc
+  primehubGroupSc: config.primehubGroupSc,
+  groupVolumeStorageClass: config.groupVolumeStorageClass,
 });
 
 // utils


### PR DESCRIPTION
Fix [ch15208](https://app.clubhouse.io/infuseai/story/15208/bug-cannot-create-groupvolume-and-dataset-by-other-storage-class-rather-than)

Test image: ch15208-09e921a


## Test cases
In helm value, configure `sharedVolumeStorageClass`
```
primehub:
  sharedVolumeStorageClass: nfs-client
```  

1. no configured `sharedVolumeStorageClass`, create group volume: create pvc with groupVolume provisioned nfs.
1. no configured `sharedVolumeStorageClass`, create pv dataset: create pvc with groupVolume provisioned nfs.
1. configured `sharedVolumeStorageClass`, create group volume: create pvc only
1. configured `sharedVolumeStorageClass`, create pv dataset: create pvc only