### PR TITLE
Add rewrite logic into graphql and proxy

### DIFF
--- a/packages/admin-server/src/proxy/index.ts
+++ b/packages/admin-server/src/proxy/index.ts
@@ -192,6 +192,7 @@ export class ProxyCtrl {
         scope
         groupName
         internalAppUrl
+        rewrite
         status
       }
     }`;
@@ -207,7 +208,7 @@ export class ProxyCtrl {
       scope: data.phApplication.scope,
       group: data.phApplication.groupName,
       target: `${internalAppUrl.protocol}//${internalAppUrl.host}`,
-      rewrite: false,
+      rewrite: data.phApplication.rewrite,
     };
   }
 

--- a/packages/graphql-server/src/crdClient/crdClientImpl.ts
+++ b/packages/graphql-server/src/crdClient/crdClientImpl.ts
@@ -272,6 +272,7 @@ export interface PhApplicationSpec {
   podTemplate: any;
   svcTemplate: any;
   httpPort: number;
+  rewrite?: boolean;
 }
 
 export interface PhApplicationStatus {
@@ -297,6 +298,7 @@ export interface PhAppTemplateSpec {
       podTemplate: any;
       svcTemplate: any;
       httpPort: number;
+      rewrite?: boolean;
     }
   };
 }

--- a/packages/graphql-server/src/ee/middlewares/auth.ts
+++ b/packages/graphql-server/src/ee/middlewares/auth.ts
@@ -20,7 +20,6 @@ export const permissions = shield({
     'phApplications': or(isAdmin, isUser, isClient),
     'phApplicationsConnection': or(isAdmin, isUser, isClient),
     'instanceType': or(isAdmin, isClient),
-    'phApplication': or(isAdmin, isUser, isClient),
     'phJob': or(isAdmin, isUser),
     'phJobs': or(isAdmin, isUser),
     'phJobsConnection': or(isAdmin, isUser),

--- a/packages/graphql-server/src/graphql/phApplication.graphql
+++ b/packages/graphql-server/src/graphql/phApplication.graphql
@@ -39,6 +39,7 @@ type PhApplication {
   status: String
   message: String
   pods: [Pod]
+  rewrite: Boolean
 }
 
 """An edge in a connection."""

--- a/packages/graphql-server/src/middlewares/auth.ts
+++ b/packages/graphql-server/src/middlewares/auth.ts
@@ -14,7 +14,6 @@ export const permissions = shield({
     'secrets': or(isAdmin, isUser, isClient),
     'image': or(isAdmin, isUser, isClient),
     'images': or(isAdmin, isUser, isClient),
-    'phApplication': or(isAdmin, isUser, isClient),
     'imagesConnection': or(isAdmin, isUser, isClient),
     'phAppTemplates': or(isAdmin, isUser, isClient),
     'phApplication': or(isAdmin, isUser, isClient),

--- a/packages/graphql-server/src/resolvers/phAppTemplate.ts
+++ b/packages/graphql-server/src/resolvers/phAppTemplate.ts
@@ -34,6 +34,7 @@ export interface PhAppTemplate {
       podTemplate: any;
       svcTemplate: any;
       httpPort: number;
+      rewrite?: boolean;
     }
   };
 }

--- a/packages/graphql-server/src/resolvers/phApplication.ts
+++ b/packages/graphql-server/src/resolvers/phApplication.ts
@@ -56,6 +56,7 @@ export interface PhApplication {
   env: EnvVar[];
   status: PhApplicationPhase;
   message: string;
+  rewrite?: boolean;
 }
 
 export interface PhApplicationMutationInput {
@@ -150,6 +151,7 @@ export const transform = async (item: Item<PhApplicationSpec, PhApplicationStatu
     env,
     status: item.status ? item.status.phase : PhApplicationPhase.Error,
     message: item.status ? item.status.message : null,
+    rewrite: item.spec.rewrite ? item.spec.rewrite : false,
   };
 };
 
@@ -267,6 +269,7 @@ const createApplication = async (context: Context, data: PhApplicationMutationIn
   const podTemplate = appTemplate.spec.template.spec && appTemplate.spec.template.spec.podTemplate;
   const svcTemplate = appTemplate.spec.template.spec && appTemplate.spec.template.spec.svcTemplate;
   let httpPort = null;
+  let rewrite = false;
 
   // Append env to pod template
   if (podTemplate.spec.containers && podTemplate.spec.containers.length > 0) {
@@ -275,6 +278,10 @@ const createApplication = async (context: Context, data: PhApplicationMutationIn
 
   if (appTemplate.spec.template.spec && appTemplate.spec.template.spec.httpPort) {
     httpPort = appTemplate.spec.template.spec.httpPort;
+  }
+
+  if (appTemplate.spec.template.spec && appTemplate.spec.template.spec.rewrite) {
+    rewrite = appTemplate.spec.template.spec.rewrite;
   }
 
   const spec = {
@@ -286,6 +293,7 @@ const createApplication = async (context: Context, data: PhApplicationMutationIn
     podTemplate,
     svcTemplate,
     httpPort,
+    rewrite,
   };
   return crdClient.phApplications.create(metadata, spec);
 };


### PR DESCRIPTION
Image Tag: `ch16532-0ed1701c`

1. Add rewrite field into GraphQL
2. Set rewrite into phapplication when creating
3. Proxy the phapplication request based on rewrite field
4. Remove the duplicated phapplication settings in auth.ts

Co-authored-by: Even Wei <evenwei@infuseai.io>
Signed-off-by: Jack Pan <jackpan@infuseai.io>