### PR TITLE
[Fix] ch16623 primehub-controller will use share secret to query data…

### DIFF
--- a/packages/graphql-server/src/ee/middlewares/auth.ts
+++ b/packages/graphql-server/src/ee/middlewares/auth.ts
@@ -9,6 +9,7 @@ export const permissions = shield({
     'user': or(isAdmin, isClient),
     'group': or(isAdmin, isClient),
     'groups': or(isAdmin, isClient),
+    'datasets': or(isAdmin, isClient),
     'secret': or(isAdmin, isUser, isClient),
     'secrets': or(isAdmin, isUser, isClient),
     'image': or(isAdmin, isUser, isClient),

--- a/packages/graphql-server/src/middlewares/auth.ts
+++ b/packages/graphql-server/src/middlewares/auth.ts
@@ -9,6 +9,7 @@ export const permissions = shield({
     'user': or(isAdmin, isClient),
     'group': or(isAdmin, isClient),
     'groups': or(isAdmin, isClient),
+    'datasets': or(isAdmin, isClient),
     'instanceType': or(isAdmin, isClient),
     'secret': or(isAdmin, isUser, isClient),
     'secrets': or(isAdmin, isUser, isClient),


### PR DESCRIPTION
Primehub-controller will use graphql share secret to query datasets information. 
Need to add permission for the client.

Signed-off-by: Kent Huang <kentwelcome@gmail.com>