### PR TITLE
tweak group settings page in user/admin portal

### DIFF
--- a/packages/client/schema/group.schema.js
+++ b/packages/client/schema/group.schema.js
@@ -243,6 +243,76 @@ export default () => (
         </relation>
       </Block>
     </Default>
+    { /* Instance Type tabular */}
+    <Default keyName="instanceTypes" title="Instance Types">
+      <Block title="${instanceTypes}">
+        <array keyName="instanceTypes"
+          packageName="../src/cms-components/customize-array-instance_in_groups"
+          uiParams={{
+            removeActions: true,
+            columns: [{
+              title: '${displayName}',
+              dataIndex: 'displayName'
+            }, {
+              title: '${description}',
+              dataIndex: 'description'
+            }, {
+              title: '${cpuLimit}',
+              dataIndex: 'cpuLimit'
+            }, {
+              title: '${memoryLimit}',
+              dataIndex: 'memoryLimit'
+            }, {
+              title: '${gpuLimit}',
+              dataIndex: 'gpuLimit'
+            }]
+          }}
+        >
+          <string keyName="id" />
+          <string keyName="displayName" title="${displayName}" />
+          <string keyName="description" title="${description}" />
+          <string keyName="cpuLimit" title="${cpuLimit}" />
+          <string keyName="memoryLimit" title="${memoryLimit}" />
+          <string keyName="gpuLimit" title="${gpuLimit}" />
+        </array>
+      </Block>
+    </Default>
+    { /* Images tabular */}
+    <Default keyName="images" match={() => !modelDeploymentOnly}  title="Images">
+      <Block title="${images}">
+        <array keyName="images"
+          packageName="../src/cms-components/customize-array-images_in_groups"
+          uiParams={{
+            removeActions: true,
+            columns: [{
+              title: '${displayName}',
+              dataIndex: 'displayName'
+            }, {
+              title: '${type}',
+              dataIndex: 'type',
+              render: (value) => {
+                if (!value) {
+                    return '-';
+                }
+                if (value === 'both') {
+                    return 'universal';
+                }
+                return value;
+              }
+            }, {
+              title: '${description}',
+              dataIndex: 'description'
+            }]
+          }}
+        >
+          <string keyName="id" />
+          <string keyName="displayName" title="${displayName}" />
+          <string keyName="type" title="${type} "/>
+          <string keyName="description" title="${description}" />
+        </array>
+      </Block>
+    </Default>
+    { /* Datasets tabular */}
     <Default keyName="dataset"  match={() => !modelDeploymentOnly} title="Datasets">
       <Block title="${dataset}">
         <array keyName="datasets"
@@ -289,75 +359,6 @@ export default () => (
         </array>
       </Block>
       <boolean keyName="writable" hidden />
-    </Default>
-    { /* Images tabular */}
-    <Default keyName="images" match={() => !modelDeploymentOnly}  title="Images">
-      <Block title="${images}">
-        <array keyName="images"
-          packageName="../src/cms-components/customize-array-images_in_groups"
-          uiParams={{
-            removeActions: true,
-            columns: [{
-              title: '${displayName}',
-              dataIndex: 'displayName'
-            }, {
-              title: '${type}',
-              dataIndex: 'type',
-              render: (value) => {
-                if (!value) {
-                    return '-';
-                }
-                if (value === 'both') {
-                    return 'universal';
-                }
-                return value;
-              }
-            }, {
-              title: '${description}',
-              dataIndex: 'description'
-            }]
-          }}
-        >
-          <string keyName="id" />
-          <string keyName="displayName" title="${displayName}" />
-          <string keyName="type" title="${type} "/>
-          <string keyName="description" title="${description}" />
-        </array>
-      </Block>
-    </Default>
-    { /* Instance Type tabular */}
-    <Default keyName="instanceTypes" title="Instance Types">
-      <Block title="${instanceTypes}">
-        <array keyName="instanceTypes"
-          packageName="../src/cms-components/customize-array-instance_in_groups"
-          uiParams={{
-            removeActions: true,
-            columns: [{
-              title: '${displayName}',
-              dataIndex: 'displayName'
-            }, {
-              title: '${description}',
-              dataIndex: 'description'
-            }, {
-              title: '${cpuLimit}',
-              dataIndex: 'cpuLimit'
-            }, {
-              title: '${memoryLimit}',
-              dataIndex: 'memoryLimit'
-            }, {
-              title: '${gpuLimit}',
-              dataIndex: 'gpuLimit'
-            }]
-          }}
-        >
-          <string keyName="id" />
-          <string keyName="displayName" title="${displayName}" />
-          <string keyName="description" title="${description}" />
-          <string keyName="cpuLimit" title="${cpuLimit}" />
-          <string keyName="memoryLimit" title="${memoryLimit}" />
-          <string keyName="gpuLimit" title="${gpuLimit}" />
-        </array>
-      </Block>
     </Default>
   </Tabs>
   </array>

--- a/packages/client/schema/group.schema.js
+++ b/packages/client/schema/group.schema.js
@@ -127,33 +127,6 @@ export default () => (
       </Condition>
       <Condition match={() => !modelDeploymentOnly} defaultMode="hidden">
         <ShareVolumn />
-        <number keyName="jobDefaultActiveDeadlineSeconds" 
-          title="${group.jobDefaultActiveDeadlineSeconds}"
-          packageName="../src/cms-components/customize-number-with_select_multiplier"
-          defaultValue={() => null}
-          nullable
-          uiParams={{
-            options: [{
-              text: 'Minutes',
-              value: 'm',
-              multiplier: 60
-            }, {
-              text: 'Hours',
-              value: 'h',
-              multiplier: 60*60
-            }, {
-              text: 'Days',
-              value: 'd',
-              multiplier: 60*60*24
-            }],
-            styleOnSelect: {width: 200},
-            defaultSelected: 1,
-            styleOnInput: {width: 100, marginRight: 10},
-            min: 0,
-            max: 999,
-            step: 1
-          }}
-        />
       </Condition>
       <Condition match={() => !modelDeploymentOnly} defaultMode="hidden">
         <Block title="User Quota">

--- a/packages/client/src/components/groupSettings/info.tsx
+++ b/packages/client/src/components/groupSettings/info.tsx
@@ -86,6 +86,32 @@ export default class GroupSettingsInfo extends React.Component<Props> {
           <Col>
             <Form.Item label={`Shared Volume`} style={{marginBottom: 20}}>
               <Switch disabled checked={group.enabledSharedVolume} />
+              {group.enabledSharedVolume ?
+                <Card title={`Shared Volume`} style={{marginTop: 10}}>
+                  <Row>
+                    <Col sm={8} xs={24}>
+                      <Form.Item label={`Shared Volume Capacity`}>
+                        <InputNumber
+                          style={{width: 'auto'}}
+                          formatter={value => `${value} GB`}
+                          value={group.sharedVolumeCapacity}
+                          disabled
+                        />
+                      </Form.Item>
+                    </Col>
+                    <Col sm={8} xs={24}>
+                      <Form.Item label={`Launch Group Only`}>
+                        <Switch
+                          checked={group.launchGroupOnly}
+                          checkedChildren="yes"
+                          unCheckedChildren="no"
+                          disabled
+                        />
+                      </Form.Item>
+                    </Col>
+                  </Row>
+                </Card>
+              : <></>}
             </Form.Item>
           </Col>
         </Row>

--- a/packages/client/src/queries/fragments/GroupInfo.graphql
+++ b/packages/client/src/queries/fragments/GroupInfo.graphql
@@ -23,4 +23,6 @@ fragment GroupInfo on Group {
   enabledDeployment
   enabledSharedVolume
   jobDefaultActiveDeadlineSeconds
+  sharedVolumeCapacity
+  launchGroupOnly
 }


### PR DESCRIPTION
Changes in Admin portal:
1. Remove `Default Timeout Setting`
1. Reorder tabs of group

![image](https://user-images.githubusercontent.com/3894670/113659493-b5aa4480-96d4-11eb-86fe-e1bee23356aa.png)

Changes in User portal:
1. Show shared volume detail when it enabled

![image](https://user-images.githubusercontent.com/3894670/113659427-914e6800-96d4-11eb-8731-e2fdde68997c.png)
