### PR TITLE
fix(template): remove single quotation for expire token

### DIFF
--- a/packages/client/public/index.ejs
+++ b/packages/client/public/index.ejs
@@ -131,8 +131,8 @@
       window.username = '<%= username %>';
       window.thumbnail = '<%= thumbnail %>';
       window.isUserAdmin = '<%= isUserAdmin %>';
-      window.accessTokenExp = '<%= accessTokenExp %>';
-      window.refreshTokenExp = '<%= refreshTokenExp %>';
+      window.accessTokenExp = <%= accessTokenExp %>;
+      window.refreshTokenExp = <%= refreshTokenExp %>;
       window.EVERYONE_GROUP_ID = '<%= everyoneGroupId %>';
       window.everyoneGroupId = '<%= everyoneGroupId %>';
       window.newAccessToken = '<%= newAccessToken %>';


### PR DESCRIPTION
## Screenshot

<img width="1409" alt="截圖 2021-06-10 下午5 21 06" src="https://user-images.githubusercontent.com/10325111/121499948-6d7b0b80-ca10-11eb-8a5d-cbf4904592dd.png">

## Description

- Remove single quotation for expiring token due to it represents a date number instead of a string.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

Signed-off-by: Jie Peng <im@jiepeng.me>