### PR TITLE
Allows customizing deployment id when creating

### DIFF
--- a/packages/client/src/ee/components/modelDeployment/createForm.tsx
+++ b/packages/client/src/ee/components/modelDeployment/createForm.tsx
@@ -166,6 +166,18 @@ class DeploymentCreateForm extends React.Component<Props, State> {
     });
   }, 400);
 
+  handleDeploymentIdCheck = (e) => {
+    this.setState({
+      customizeId: e.target.checked,
+      customizeIdValidateStatus: null,
+      customizeIdHelp: null,
+    });
+
+    if (!e.target.checked) {
+      this.handleNameChange();
+    }
+  };
+
   handleIdChange = debounce(async (client: ApolloClient<any>, deploymentId) => {
     const rules = /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/;
     if (!deploymentId) {
@@ -227,44 +239,55 @@ class DeploymentCreateForm extends React.Component<Props, State> {
   }
 
   renderDeploymentIdFormItem = (initialValue) => {
-    const {form, type} = this.props;
+    const { form, type } = this.props;
 
     const { customizeId, customizeIdValidateStatus, customizeIdHelp } = this.state;
-    return (
-      <ApolloConsumer>
-        {client => <Form.Item
-          label={<span>Deployment ID <PHTooltip tipText='Check the box to customize your Deployment ID. The ID should be unique in PrimeHub' tipLink='https://docs.primehub.io/docs/model-deployment-feature#deployment-details' placement='right' style={{margintLeft: 8}}/></span>}
+
+    const _renderItem = (client) => {
+      const formLabel = (
+        <span>
+          Deployment ID{' '}
+          <PHTooltip
+            tipText="Check the box to customize your Deployment ID. The ID should be unique in PrimeHub"
+            tipLink="https://docs.primehub.io/docs/model-deployment-feature#deployment-details"
+            placement="right"
+            style={{ margintLeft: 8 }}
+          />
+        </span>
+      );
+
+      const cbDeploymentId = (
+        <Checkbox
+          style={{ marginRight: 8 }}
+          onChange={this.handleDeploymentIdCheck}
+        />
+      );
+
+      return (
+        <Form.Item
+          label={formLabel}
           hasFeedback={customizeId}
           validateStatus={customizeIdValidateStatus}
           help={customizeIdHelp}
           required
         >
-          {type === 'create' ? <Checkbox
-            style={{ marginRight: 8 }}
-            onChange={(e) => {
-              this.setState({
-                customizeId: e.target.checked,
-                customizeIdValidateStatus: null,
-                customizeIdHelp: null,
-              });
-
-              if (!e.target.checked) {
-                this.handleNameChange();
-              }
-            }}
-
-
-          /> : null}
-          {form.getFieldDecorator('id', {initialValue})(
+          {type === 'create' ? cbDeploymentId : null}
+          {form.getFieldDecorator('id', { initialValue })(
             <Input
-              style={{ width: type === 'create' ? 'calc(100% - 24px)' : '100%' }}
+              style={{
+                width: type === 'create' ? 'calc(100% - 24px)' : '100%',
+              }}
               disabled={!customizeId}
-              onChange={(e) => {this.handleIdChange(client, e.target.value)}}
-          />)
-          }
-        </Form.Item>}
-      </ApolloConsumer>
-    );
+              onChange={(e) => {
+                this.handleIdChange(client, e.target.value);
+              }}
+            />
+          )}
+        </Form.Item>
+      );
+    };
+
+    return <ApolloConsumer>{(client) => _renderItem(client)}</ApolloConsumer>;
   };
 
   render() {

--- a/packages/client/src/ee/components/modelDeployment/createForm.tsx
+++ b/packages/client/src/ee/components/modelDeployment/createForm.tsx
@@ -123,9 +123,11 @@ class DeploymentCreateForm extends React.Component<Props, State> {
 
   submit = (e) => {
     const {form, onSubmit} = this.props;
+    const {customizeIdValidateStatus} = this.state;
     e.preventDefault();
     form.validateFields(async (err, values: FormValue) => {
       if (err) return;
+      if (customizeIdValidateStatus === 'error') return;
       if (!values.metadata) values.metadata = {}
       values.endpointAccessType = values.privateAccess ? 'private' : 'public';
       delete values.privateAccess;
@@ -157,8 +159,13 @@ class DeploymentCreateForm extends React.Component<Props, State> {
   }
 
   handleNameChange = debounce(() => {
-    const {form} = this.props;
-    const values = form.getFieldsValue();
+    const { form } = this.props;
+    const { customizeId } = this.state;
+
+    if (customizeId) {
+      return;
+    }
+
     form.validateFields(['name'], (err, values) => {
       if (err) return form.setFieldsValue({ id: '' });
       const id = autoGenId(values.name);
@@ -197,14 +204,11 @@ class DeploymentCreateForm extends React.Component<Props, State> {
       return;
     }
 
-
     const CHECK_DEPLOYMENT_AVAIL = gql`
       query checkDeploymentAvail($deploymentId: ID!) {
         phDeploymentAvail(where: {id: $deploymentId})
       }
     `;
-
-    const {form} = this.props;
 
     this.setState({
       customizeIdValidateStatus: 'validating',
@@ -222,7 +226,7 @@ class DeploymentCreateForm extends React.Component<Props, State> {
     if (avail) {
       this.setState({
         customizeIdValidateStatus: 'success',
-        customizeIdHelp: null,
+        customizeIdHelp: `${deploymentId} is avaiable`,
       });
     } else {
       this.setState({

--- a/packages/client/src/ee/components/modelDeployment/createForm.tsx
+++ b/packages/client/src/ee/components/modelDeployment/createForm.tsx
@@ -226,7 +226,7 @@ class DeploymentCreateForm extends React.Component<Props, State> {
     if (avail) {
       this.setState({
         customizeIdValidateStatus: 'success',
-        customizeIdHelp: `${deploymentId} is avaiable`,
+        customizeIdHelp: `Your Deployment ID is available. Uncheck the box will reset this id.`,
       });
     } else {
       this.setState({

--- a/packages/client/src/ee/containers/deploymentCreatePage.tsx
+++ b/packages/client/src/ee/containers/deploymentCreatePage.tsx
@@ -1,20 +1,19 @@
 import * as React from 'react';
 import gql from 'graphql-tag';
-import {notification} from 'antd';
-import {graphql} from 'react-apollo';
-import {compose} from 'recompose';
-import {get, unionBy, pick} from 'lodash';
+import { notification } from 'antd';
+import { graphql } from 'react-apollo';
+import { compose } from 'recompose';
+import { get, unionBy, pick } from 'lodash';
 import queryString from 'querystring';
-import {RouteComponentProps} from 'react-router';
-import {withRouter} from 'react-router-dom';
-import {errorHandler} from 'utils/errorHandler';
+import { RouteComponentProps } from 'react-router';
+import { withRouter } from 'react-router-dom';
+import { errorHandler } from 'utils/errorHandler';
 import DeploymentCreateForm from 'ee/components/modelDeployment/createForm';
-import {appPrefix} from 'utils/env';
 import PageTitle from 'components/pageTitle';
-import {GroupContextComponentProps, withGroupContext} from 'context/group';
+import { GroupContextComponentProps, withGroupContext } from 'context/group';
 import Breadcrumbs from 'components/share/breadcrumb';
-import {sortNameByAlphaBet} from 'utils/sorting';
-import {CurrentUser} from 'queries/User.graphql';
+import { sortNameByAlphaBet } from 'utils/sorting';
+import { CurrentUser } from 'queries/User.graphql';
 
 const breadcrumbs = [
   {
@@ -106,6 +105,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
         />
         <div style={{margin: '16px'}}>
           <DeploymentCreateForm
+            type="create"
             groupContext={groupContext}
             refetchGroup={currentUser.refetch}
             onSelectGroup={this.onChangeGroup}

--- a/packages/client/src/ee/containers/deploymentEditPage.tsx
+++ b/packages/client/src/ee/containers/deploymentEditPage.tsx
@@ -144,7 +144,7 @@ class DeploymentCreatePage extends React.Component<Props, State> {
         />
         <div style={{margin: '16px'}}>
           <DeploymentCreateForm
-            type='edit'
+            type="edit"
             initialValue={{
               ...(getPhDeployment.phDeployment || {}),
               instanceTypeId: get(getPhDeployment, 'phDeployment.instanceType.id', ''),

--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -105,6 +105,7 @@ const eeResolvers = {
     phSchedules: phSchedule.query,
     phSchedulesConnection: phSchedule.connectionQuery,
     phDeployment: phDeployment.queryOne,
+    phDeploymentAvail: phDeployment.avaliable,
     phDeployments: phDeployment.query,
     phDeploymentsConnection: phDeployment.connectionQuery,
     usageReports: usageReport.query,

--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -105,7 +105,7 @@ const eeResolvers = {
     phSchedules: phSchedule.query,
     phSchedulesConnection: phSchedule.connectionQuery,
     phDeployment: phDeployment.queryOne,
-    phDeploymentAvail: phDeployment.avaliable,
+    phDeploymentAvail: phDeployment.available,
     phDeployments: phDeployment.query,
     phDeploymentsConnection: phDeployment.connectionQuery,
     usageReports: usageReport.query,

--- a/packages/graphql-server/src/ee/graphql/ee.graphql
+++ b/packages/graphql-server/src/ee/graphql/ee.graphql
@@ -100,6 +100,7 @@ type Query {
 
   """PhDeployment"""
   phDeployment(where: PhDeploymentWhereUniqueInput!): PhDeployment!
+  phDeploymentAvail(where: PhDeploymentWhereUniqueInput!): Boolean!
   phDeployments(
     where: PhDeploymentWhereInput
     before: String

--- a/packages/graphql-server/src/ee/middlewares/auth.ts
+++ b/packages/graphql-server/src/ee/middlewares/auth.ts
@@ -28,6 +28,7 @@ export const permissions = shield({
     'phSchedules': or(isAdmin, isUser),
     'phSchedulesConnection': or(isAdmin, isUser),
     'phDeployment': or(isAdmin, isUser),
+    'phDeploymentAvail': or(isAdmin, isUser),
     'phDeployments': or(isAdmin, isUser),
     'phDeploymentsConnection': or(isAdmin, isUser),
     'license': or(isAdmin, isUser),

--- a/packages/graphql-server/src/ee/resolvers/phDeployment.ts
+++ b/packages/graphql-server/src/ee/resolvers/phDeployment.ts
@@ -517,15 +517,15 @@ export const available = async (root, args, context: Context) => {
   const {crdClient} = context;
   const where = args && args.where;
   if (where) {
-    const rules = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]$/
+    const rules = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]$/;
     if (!rules.test(where.id)) {
       return false;
     }
     try {
       await crdClient.phDeployments.get(where.id);
     } catch (error) {
-      if (error.data && error.data.code && error.data.code == "RESOURCE_NOT_FOUND") {
-        return true
+      if (error.data && error.data.code && error.data.code === 'RESOURCE_NOT_FOUND') {
+        return true;
       }
       logger.info({
         component: logger.components.phDeployment,

--- a/packages/graphql-server/src/ee/resolvers/phDeployment.ts
+++ b/packages/graphql-server/src/ee/resolvers/phDeployment.ts
@@ -517,7 +517,7 @@ export const available = async (root, args, context: Context) => {
   const {crdClient} = context;
   const where = args && args.where;
   if (where) {
-    const rules = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]$/;
+    const rules = /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/;
     if (!rules.test(where.id)) {
       return false;
     }

--- a/packages/graphql-server/src/ee/resolvers/phDeployment.ts
+++ b/packages/graphql-server/src/ee/resolvers/phDeployment.ts
@@ -513,6 +513,30 @@ export const destroy = async (root, args, context: Context) => {
   return {id};
 };
 
+export const available = async (root, args, context: Context) => {
+  const {crdClient} = context;
+  const where = args && args.where;
+  if (where) {
+    const rules = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]$/
+    if (!rules.test(where.id)) {
+      return false;
+    }
+    try {
+      await crdClient.phDeployments.get(where.id);
+    } catch (error) {
+      if (error.data && error.data.code && error.data.code == "RESOURCE_NOT_FOUND") {
+        return true
+      }
+      logger.info({
+        component: logger.components.phDeployment,
+        type: 'GET_DEPLOYMENT_ERROR',
+        id: where.id,
+      });
+    }
+  }
+  return false;
+};
+
 export interface PhDeploymentClient {
   id: string;
   deploymentId: string;


### PR DESCRIPTION

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
feature

**What this PR does / why we need it**:
The deployment id is part of the prediction endpoint path. We would like to allow users to customize the deployment id so they can determine the endpoint for users.

**Which issue(s) this PR fixes**:
ch17708

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes

```release-note
[EE feature] Allow users to customize the deployment id so they can determine the endpoint for users.
```
