### PR TITLE
Allow to pass the hub outer querystring to internal iframe querystring

### DIFF
--- a/packages/client/src/containers/JupyterHubPage/index.tsx
+++ b/packages/client/src/containers/JupyterHubPage/index.tsx
@@ -25,7 +25,10 @@ export function JupyterHubContainer({ groupContext, location }: Props) {
     },
   ];
 
-  const params = queryString.parse(location.search.replace(/^\?/, '')) || {};
+  let params:any = {};
+  if (location.search) {
+    params = queryString.parse(location.search.replace(/^\?/, ''));
+  }
   params.group = groupContext.name;
   const qs = queryString.stringify(params);
 

--- a/packages/client/src/containers/JupyterHubPage/index.tsx
+++ b/packages/client/src/containers/JupyterHubPage/index.tsx
@@ -10,10 +10,11 @@ import PageBody from 'components/pageBody';
 import Breadcrumbs from 'components/share/breadcrumb';
 import { IFrame } from 'components/hub/iframe';
 import { withGroupContext, GroupContextComponentProps } from 'context/group';
+import queryString from 'querystring';
 
 type Props = GroupContextComponentProps & RouteComponentProps;
 
-export function JupyterHubContainer({ groupContext }: Props) {
+export function JupyterHubContainer({ groupContext, location }: Props) {
   const breadcrumbs = [
     {
       key: 'hub',
@@ -24,6 +25,10 @@ export function JupyterHubContainer({ groupContext }: Props) {
     },
   ];
 
+  const params = queryString.parse(location.search.replace(/^\?/, '')) || {};
+  params.group = groupContext.name;
+  const qs = queryString.stringify(params);
+
   return (
     <>
       <PageTitle breadcrumb={<Breadcrumbs pathList={breadcrumbs} />} />
@@ -32,7 +37,7 @@ export function JupyterHubContainer({ groupContext }: Props) {
         <Tabs style={{ height: '100%' }}>
           <Tabs.TabPane key="information" tab="Notebooks">
             <div style={{ height: 'calc(100vh - 310px)' }}>
-              <IFrame src={`/hub/primehub/home?group=${groupContext.name}`} />
+              <IFrame src={`/hub/primehub/home?${qs}`} />
             </div>
           </Tabs.TabPane>
           <Tabs.TabPane key="logs" tab="Logs">


### PR DESCRIPTION
Signed-off-by: popcorny <celu@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
New Feature

**What this PR does / why we need it**:
Allows jupyterhub iframe to get the url params from the outer frame.

**Which issue(s) this PR fixes**:
ch17904 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
