### PR TITLE
backport 3.6: ce should not have model deployment switch

### DIFF
--- a/packages/client/schema/group.schema.js
+++ b/packages/client/schema/group.schema.js
@@ -118,7 +118,7 @@ export default () => (
       </Condition>
 
       <string keyName="displayName" title="${displayName}" />
-      <Condition match={() => !modelDeploymentOnly} defaultMode="hidden">
+      <Condition match={() => !modelDeploymentOnly && !primehubCE} defaultMode="hidden">
        {/* Hidden enable EnableModelDeployment
          * because in "deploy" mode it is always enabled. */}
         <Layout component={EnableModelDeployment}>


### PR DESCRIPTION
Signed-off-by: Eric Yang ericy@infuseai.io  
Co-authored-by: Timothy Lee ctiml@infuseai.io

- do not show "model deployment" switch in CE