### PR TITLE
Add simple max deploy check in graphql and add `Maximum Deployment` input on Group form.

### DIFF
--- a/packages/client/schema/group.schema.js
+++ b/packages/client/schema/group.schema.js
@@ -79,6 +79,7 @@ export default () => (
               projectQuotaCpu
               projectQuotaGpu
               sharedVolumeCapacity
+              maxDeploy
               admins
             }
           }
@@ -124,6 +125,13 @@ export default () => (
         <Layout component={EnableModelDeployment}>
           <boolean keyName="enabledDeployment" uiParams={{yesText: ' ', noText: ' '}} />
         </Layout>
+        <number keyName="maxDeploy"
+          uiParams={{min: 0, step: 1, precision: 0}}
+          defaultValue={() => null}
+          title="Maximum Deployment"
+          packageName="../src/cms-components/customize-number-checkbox"
+          nullable
+        />
       </Condition>
       <Condition match={() => !modelDeploymentOnly} defaultMode="hidden">
         <ShareVolume />

--- a/packages/graphql-server/src/ee/resolvers/phDeployment.ts
+++ b/packages/graphql-server/src/ee/resolvers/phDeployment.ts
@@ -182,7 +182,7 @@ const createDeployment = async (context: Context, data: PhDeploymentMutationInpu
   const group = await kcAdminClient.groups.findOne({id: data.groupId});
   const maxDeploy = get(group.attributes, 'max-deploy', UNLIMITED);
   const deployments = await crdClient.phDeployments.list() || [];
-  const deployCount = deployments.filter((d) => d.spec.groupId == data.groupId).length;
+  const deployCount = deployments.filter(d => d.spec.groupId === data.groupId).length;
   if (maxDeploy !== UNLIMITED && deployCount >= maxDeploy) {
     throw new ApolloError('Group Maximum Deployments exceeded', EXCEED_QUOTA_ERROR);
   }

--- a/packages/graphql-server/src/graphql/group.graphql
+++ b/packages/graphql-server/src/graphql/group.graphql
@@ -47,6 +47,7 @@ type Group {
   launchGroupOnly: Boolean
   # enabledDeployment
   enabledDeployment: Boolean
+  maxDeploy: Int
   jobDefaultActiveDeadlineSeconds: Int
   # group admin
   admins: String
@@ -130,6 +131,7 @@ input GroupCreateInput {
   instanceTypes: InstancePlaceHolder
   # enabledDeployment
   enabledDeployment: Boolean
+  maxDeploy: Int
   jobDefaultActiveDeadlineSeconds: Int
   # group admin
   admins: String
@@ -160,6 +162,7 @@ input GroupUpdateInput {
   instanceTypes: InstancePlaceHolder
   # enabledDeployment
   enabledDeployment: Boolean
+  maxDeploy: Int
   jobDefaultActiveDeadlineSeconds: Int
   # group admin
   admins: String

--- a/packages/graphql-server/src/resolvers/group.ts
+++ b/packages/graphql-server/src/resolvers/group.ts
@@ -49,6 +49,7 @@ const attrSchema = {
   homeSymlink: {type: FieldType.boolean, rename: 'home-symlink'},
   launchGroupOnly: {type: FieldType.boolean, rename: 'launch-group-only'},
   enabledDeployment: {type: FieldType.boolean, rename: 'enabled-deployment'},
+  maxDeploy: {type: FieldType.integer, rename: 'max-deploy'},
   jobDefaultActiveDeadlineSeconds: {type: FieldType.integer, rename: 'job-default-active-deadline-seconds'},
   // group admin
   admins: {serialize: splitByComma, deserialize: joinByComma},

--- a/packages/graphql-server/src/resolvers/groupUtils.ts
+++ b/packages/graphql-server/src/resolvers/groupUtils.ts
@@ -26,6 +26,7 @@ export const transform = (group: any): any => {
     homeSymlink: getFromAttr('home-symlink', group.attributes, null, parseBoolean),
     launchGroupOnly: getFromAttr('launch-group-only', group.attributes, null, parseBoolean),
     enabledDeployment: getFromAttr('enabled-deployment', group.attributes, null, parseBoolean),
+    maxDeploy: getFromAttr('max-deploy', group.attributes, null, parseInt),
     displayName: getFromAttr('displayName', group.attributes, null),
     jobDefaultActiveDeadlineSeconds: getFromAttr('job-default-active-deadline-seconds',
                                                   group.attributes, null, parseInt),


### PR DESCRIPTION
### outline

- Add new schema in group graphql `maxDeploy`.
- Save it in kc group attr.
- Add new field in group form on admin portal.

### screenshots

<img width="817" alt="CleanShot 2021-07-15 at 14 48 30@2x" src="https://user-images.githubusercontent.com/935988/125742036-5995a290-eb91-4c06-b440-0b3c3ee53f20.png">

<img width="733" alt="CleanShot 2021-07-15 at 14 41 19@2x" src="https://user-images.githubusercontent.com/935988/125741746-ad1dfd61-0fc4-453b-839b-e6850b625966.png">


Signed-off-by: Aaron Huang <aaroms9733@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
