### PR TITLE
fix(deployment): remove redundant field and add lastExecutor field

### DIFF
--- a/packages/client/src/queries/PhDeployment.graphql
+++ b/packages/client/src/queries/PhDeployment.graphql
@@ -13,6 +13,7 @@ fragment PhDeploymentInfo on PhDeployment {
   groupId
   groupName
   creationTime
+  lastExecutor
   lastUpdatedTime
   endpoint
   endpointAccessType

--- a/packages/graphql-server/src/ee/graphql/phDeployment.graphql
+++ b/packages/graphql-server/src/ee/graphql/phDeployment.graphql
@@ -47,6 +47,35 @@ type PhDeployment {
   imagePullSecret: String
   instanceType: InstanceType
   creationTime: String
+  pods: [Pod]
+  history: [HistoryItem]
+  env: [EnvVar]
+  endpointAccessType: String
+  endpointClients: [PhDeploymentClient]
+}
+
+type PhDeploymentNode {
+  id: ID!
+  status: String
+  message: String
+  name: String
+  description: String
+  updateMessage: String
+  metadata: JSON
+  stop: Boolean
+  userId: String
+  userName: String
+  groupId: String
+  groupName: String
+  endpoint: String
+  modelImage: String
+  modelURI: String
+  replicas: Int
+  availableReplicas: Int
+  imagePullSecret: String
+  instanceType: InstanceType
+  creationTime: String
+  lastExecutor: String
   lastUpdatedTime: String
   pods: [Pod]
   history: [HistoryItem]
@@ -58,7 +87,7 @@ type PhDeployment {
 """An edge in a connection."""
 type PhDeploymentEdge {
   """The item at the end of the edge."""
-  node: PhDeployment!
+  node: PhDeploymentNode!
 
   """A cursor for use in pagination."""
   cursor: String!

--- a/packages/graphql-server/src/ee/resolvers/phDeployment.ts
+++ b/packages/graphql-server/src/ee/resolvers/phDeployment.ts
@@ -49,6 +49,7 @@ export interface PhDeployment {
   imagePullSecret: string;
   instanceType: string;
   creationTime: string;
+  lastExecutor: string;
   lastUpdatedTime: string;
   history: Array<{time: string, deployment: any}>;
   endpointAccessType: string;
@@ -94,6 +95,7 @@ const transformSpec = (id: string, time: string, groupName: string, spec: any) =
     };
   });
   const endpointAccessType = get(spec, 'endpoint.accessType', 'public');
+
   return {
     id: `${id}-${time}`,
     name: spec.displayName,
@@ -104,7 +106,6 @@ const transformSpec = (id: string, time: string, groupName: string, spec: any) =
     groupName,
     groupId: spec.groupId,
     stop: isUndefined(spec.stop) ? false : spec.stop,
-    lastUpdatedTime: spec.updateTime,
     env: spec.env,
 
     endpointClients,
@@ -167,6 +168,7 @@ export const transform = async (item: Item<PhDeploymentSpec, PhDeploymentStatus>
 
     // times
     creationTime: item.metadata.creationTimestamp,
+    lastExecutor: item.spec.userName,
     lastUpdatedTime: item.spec.updateTime,
 
     // history


### PR DESCRIPTION
## Description

- Removed `lastUpdatedTime` from `PhDeployment` field because it's confusing.
- Added `PhDeploymentNode` type for the representation node type and also includes `lastUpdateTime` and `lastExecutor` fields

Signed-off-by: Jie Peng <im@jiepeng.me>

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed