### PR TITLE
style(admin): remove h2 title and remove margin

### DIFF
--- a/packages/client/src/admin/Secrets/Layout.tsx
+++ b/packages/client/src/admin/Secrets/Layout.tsx
@@ -11,25 +11,19 @@ export function SecretLayout({ children }: { children: React.ReactNode }) {
           padding: '16px 24px',
         }}
       >
-        <div
-          style={{
-            marginBottom: 24,
-          }}
-        >
-          <Breadcrumbs
-            pathList={[
-              {
-                key: 'secret',
-                matcher: /\/secret/,
-                title: 'Secret',
-                link: 'admin/secret',
-                tips: 'Secrets are credentials of authorizations to certain images anddatasets. Admin can find and manage secrets here.',
-                tipsLink:
-                  'https://docs.primehub.io/docs/guide_manual/admin-secret',
-              },
-            ]}
-          />
-        </div>
+        <Breadcrumbs
+          pathList={[
+            {
+              key: 'secret',
+              matcher: /\/secret/,
+              title: 'Secrets',
+              link: 'admin/secret',
+              tips: 'Secrets are credentials of authorizations to certain images anddatasets. Admin can find and manage secrets here.',
+              tipsLink:
+                'https://docs.primehub.io/docs/guide_manual/admin-secret',
+            },
+          ]}
+        />
       </div>
 
       {children}

--- a/packages/client/src/admin/SystemSetting/SystemSetting.tsx
+++ b/packages/client/src/admin/SystemSetting/SystemSetting.tsx
@@ -234,23 +234,15 @@ function _SystemSetting({ data, ...props }: Props) {
           padding: '16px 24px',
         }}
       >
-        <div
-          style={{
-            marginBottom: 24,
-          }}
-        >
-          <Breadcrumbs
-            pathList={[
-              {
-                key: 'system',
-                matcher: /\/system/,
-                title: 'System Settings',
-              },
-            ]}
-          />
-        </div>
-
-        <h2>System Settings</h2>
+        <Breadcrumbs
+          pathList={[
+            {
+              key: 'system',
+              matcher: /\/system/,
+              title: 'System Settings',
+            },
+          ]}
+        />
       </div>
 
       <div


### PR DESCRIPTION
## Screenshots

### System settings
<img width="1198" alt="截圖 2021-08-09 上午11 34 47" src="https://user-images.githubusercontent.com/10325111/128657939-5585eb35-85d1-4ff4-af53-f8370347511e.png">

### Secrets
<img width="1205" alt="截圖 2021-08-09 上午11 35 01" src="https://user-images.githubusercontent.com/10325111/128657941-c53c531f-ae69-40a1-be92-a498ef0537f5.png">

## Descriptions

- Fixed breadcrumb typo
- Removed redundant title and margin

Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed
