### PR TITLE
update secret: type should be read-only

### DIFF
--- a/packages/client/src/admin/Secrets/SecretForm.tsx
+++ b/packages/client/src/admin/Secrets/SecretForm.tsx
@@ -140,6 +140,7 @@ export function _SecretForm({ form, data, ...props }: SecretFormProps) {
             <Select
               data-testid='secret-type'
               onChange={value => setSecretType(value as SecretType)}
+              disabled={props?.disabledName || false}
             >
               <Select.Option value='opaque'>Git Dataset</Select.Option>
               <Select.Option value='kubernetes'>Image Pull</Select.Option>

--- a/packages/client/src/admin/Secrets/__tests__/SecretInfo.spec.tsx
+++ b/packages/client/src/admin/Secrets/__tests__/SecretInfo.spec.tsx
@@ -91,27 +91,4 @@ describe('SecretInfo', () => {
     });
   });
 
-  it('should render image pull related fields with change secret type', async () => {
-    const { TestProvider, mockRequests } = setup();
-
-    render(
-      <TestProvider>
-        <MockedProvider mocks={mockRequests}>
-          <SecretInfo />
-        </MockedProvider>
-      </TestProvider>
-    );
-
-    const secretType = await screen.findByTestId('secret-type');
-    userEvent.click(secretType);
-
-    const imagePullOption = await screen.findByText('Image Pull');
-    userEvent.click(imagePullOption);
-
-    await waitFor(() => {
-      expect(screen.getByText('Registry Host')).toBeInTheDocument();
-      expect(screen.getByText('Username')).toBeInTheDocument();
-      expect(screen.getByText('Password')).toBeInTheDocument();
-    });
-  });
 });


### PR DESCRIPTION
Signed-off-by: Eric Yang <ericy@infuseai.io>

- make the type of secret to be read-only in edit mode
- same behavior as Type in datasets