### PR TITLE
[bug] fix model deployment settings in primehub ce/ee/deploy

### DIFF
--- a/packages/client/src/admin/Group/Form.tsx
+++ b/packages/client/src/admin/Group/Form.tsx
@@ -310,6 +310,8 @@ function GroupForm(props: Props) {
               />
             )}
           </Form.Item>
+        </FeatureEE>
+        <Feature ce={false}>
           {form.getFieldValue('enabledDeployment') ? (
             <Form.Item label={`Maximum Deployment(s)`}>
               {form.getFieldDecorator('maxDeploy', {
@@ -325,7 +327,7 @@ function GroupForm(props: Props) {
           ) : (
             <></>
           )}
-        </FeatureEE>
+        </Feature>
         <Feature modelDeploy={false}>
           <Form.Item
             label={

--- a/packages/client/src/admin/Group/__tests__/update.spec.tsx
+++ b/packages/client/src/admin/Group/__tests__/update.spec.tsx
@@ -15,14 +15,15 @@ describe('Admin Portal - Group Update', () => {
       </IntlProvider>
     );
   };
-  beforeEach(() => {
+
+
+  it('Render Group list with breadcrumb', () => {
+
     // @ts-ignore
     global.modelDeploymentOnly = false;
     // @ts-ignore
     global.__ENV__ = 'ee';
-  });
 
-  it('Render Group list with breadcrumb', () => {
     render(
       <MockedProvider mocks={[]}>
         <GroupUpdate />
@@ -30,5 +31,42 @@ describe('Admin Portal - Group Update', () => {
       { wrapper }
     );
     expect(screen.queryByText('Info')).toBeInTheDocument();
+    expect(screen.queryByText('Model Deployment')).toBeInTheDocument();
+  });
+
+  it('Render ce-related settings in group settings', () => {
+    global.__ENV__ = 'ce';
+    render(
+      <MockedProvider mocks={[]}>
+        <GroupUpdate />
+      </MockedProvider>,
+      { wrapper }
+    );
+    expect(screen.queryByText('Share Volume')).toBeInTheDocument();
+    expect(screen.queryByText('Model Deployment')).not.toBeInTheDocument();
+  });
+
+  it('Render ee-related settings in group settings', () => {
+    global.__ENV__ = 'ee';
+    render(
+      <MockedProvider mocks={[]}>
+        <GroupUpdate />
+      </MockedProvider>,
+      { wrapper }
+    );
+    expect(screen.queryByText('Share Volume')).toBeInTheDocument();
+    expect(screen.queryByText('Model Deployment')).toBeInTheDocument();
+  });
+
+  it('Render deploy-related settings in group settings', () => {
+    global.__ENV__ = 'modelDeploy';
+    render(
+      <MockedProvider mocks={[]}>
+        <GroupUpdate />
+      </MockedProvider>,
+      { wrapper }
+    );
+    expect(screen.queryByText('Share Volume')).not.toBeInTheDocument();
+    expect(screen.queryByText('Model Deployment')).not.toBeInTheDocument();
   });
 });

--- a/packages/client/src/components/groupSettings/info.tsx
+++ b/packages/client/src/components/groupSettings/info.tsx
@@ -109,31 +109,6 @@ export default class GroupSettingsInfo extends React.Component<Props> {
           ) : (
             <Row>
               <Col>
-                <Form.Item
-                  label={`Model Deployment`}
-                  style={{ marginBottom: 20 }}
-                >
-                  <Switch disabled checked={group.enabledDeployment} />
-                </Form.Item>
-              </Col>
-            </Row>
-          )
-        }
-        <Row>
-          <Col>
-            {this.renderInfoQuotaFormItem(
-              'Maximum Deployment(s)',
-              group.maxDeploy,
-              { min: 0, step: 1, percision: 1 }
-            )}
-          </Col>
-        </Row>
-        {
-          __ENV__ === 'modelDeploy' ? (
-            <></>
-          ) : (
-            <Row>
-              <Col>
                 <Form.Item label={`Shared Volume`} style={{ marginBottom: 20 }}>
                   <Switch disabled checked={group.enabledSharedVolume} />
                   {group.enabledSharedVolume ? (

--- a/packages/client/src/ee/components/groupSettings/__tests__/deployments.tsx
+++ b/packages/client/src/ee/components/groupSettings/__tests__/deployments.tsx
@@ -10,6 +10,7 @@ function setup() {
     displayName: 'Test Group',
     admins: 'test',
     enabledDeployment: true,
+    maxDeploy: 5,
   };
 
   const user = {
@@ -34,6 +35,7 @@ function setup() {
 describe('GroupSettingsDeployments Component', () => {
   it('Should render group settings models', () => {
     const { group, user, currentUser } = setup();
+    global.__ENV__ = 'ee';
     render(
       <MockedProvider>
         <GroupSettingsDeployments currentUser={currentUser} groupContext={group} userContext={user} />
@@ -41,5 +43,18 @@ describe('GroupSettingsDeployments Component', () => {
     );
     expect(screen.queryByText('Model Deployment')).toBeInTheDocument();
     expect(screen.getByRole('switch')).toBeChecked();
+    expect(screen.queryByDisplayValue('5')).toBeInTheDocument();
+  });
+  it('Should not render model deployment switch when env modelDeploy', () => {
+    const { group, user, currentUser } = setup();
+    // @ts-ignore
+    global.__ENV__ = 'modelDeploy';
+    render(
+      <MockedProvider>
+        <GroupSettingsDeployments currentUser={currentUser} groupContext={group} userContext={user} />
+      </MockedProvider>
+    );
+    expect(screen.queryByText('Model Deployment')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('5')).toBeInTheDocument();
   });
 });

--- a/packages/client/src/ee/components/groupSettings/deployments.tsx
+++ b/packages/client/src/ee/components/groupSettings/deployments.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { Form, Tabs, Row, Col, Switch, notification } from 'antd';
+import { Form, Tabs, Row, Col, Switch, notification, Checkbox, Input, InputNumber } from 'antd';
 import { FormComponentProps } from 'antd/lib/form';
-import { get } from 'lodash';
+import { get, isNull } from 'lodash';
 import { RouteComponentProps } from 'react-router-dom';
 import { GroupContextComponentProps } from 'context/group';
 import { UserContextComponentProps } from 'context/user';
 import GroupSettingsAlert from 'components/groupSettings/alert';
+import Feature, { FeatureEE } from 'components/share/feature';
 
 type Props = FormComponentProps & {
   currentUser: any;
@@ -16,6 +17,14 @@ type Props = FormComponentProps & {
 interface State {
   group: any;
 }
+
+const inputNumberStyle = {
+  width: 193,
+};
+
+const checkboxStyle = {
+  marginRight: 8,
+};
 
 class GroupSettingsDeployments extends React.Component<Props, State> {
   constructor(props) {
@@ -45,6 +54,31 @@ class GroupSettingsDeployments extends React.Component<Props, State> {
     }
   }
 
+  renderInfoQuotaFormItem(title, value, params) {
+    return (
+      <Form.Item label={title}>
+        <div style={{ alignItems: 'center' }}>
+          <Checkbox style={checkboxStyle} checked={!isNull(value)} disabled />
+          {isNull(value) ? (
+            <Input style={inputNumberStyle} value={'unlimited'} disabled />
+          ) : (
+            <InputNumber
+              style={inputNumberStyle}
+              min={params && params.min}
+              step={params && params.step}
+              precision={params && params.precision}
+              formatter={(value) =>
+                `${value}${params && params.unit ? params.unit : ''}`
+              }
+              value={value}
+              disabled
+            />
+          )}
+        </div>
+      </Form.Item>
+    );
+  }
+
   render() {
     const { groupContext, userContext, currentUser, history, form } =
       this.props;
@@ -53,19 +87,32 @@ class GroupSettingsDeployments extends React.Component<Props, State> {
       <>
         <GroupSettingsAlert />
         <Form>
-          <Row style={{ marginTop: 5, marginLeft: 5, marginRight: 5 }}>
-            <Col>
-              <Form.Item
-                label={`Model Deployment`}
-                style={{ marginBottom: 20 }}
-              >
-                {form.getFieldDecorator('enabledDeployment', {
-                  initialValue: group.enabledDeployment,
-                  valuePropName: 'checked',
-                })(<Switch disabled />)}
-              </Form.Item>
-            </Col>
-          </Row>
+          <FeatureEE>
+            <Row style={{ marginTop: 5, marginLeft: 5, marginRight: 5 }}>
+              <Col>
+                <Form.Item
+                  label={`Model Deployment`}
+                  style={{ marginBottom: 20 }}
+                >
+                  {form.getFieldDecorator('enabledDeployment', {
+                    initialValue: group.enabledDeployment,
+                    valuePropName: 'checked',
+                  })(<Switch disabled />)}
+                </Form.Item>
+              </Col>
+            </Row>
+          </FeatureEE>
+          <Feature ce={false}>
+            <Row>
+              <Col>
+                {this.renderInfoQuotaFormItem(
+                  'Maximum Deployment(s)',
+                  group.maxDeploy,
+                  { min: 0, step: 1, percision: 1 }
+                )}
+              </Col>
+            </Row>
+          </Feature>
         </Form>
       </>
     );

--- a/packages/client/src/ee/main.model_deploy.tsx
+++ b/packages/client/src/ee/main.model_deploy.tsx
@@ -22,6 +22,7 @@ import DeploymentDetailContainer from 'ee/containers/deploymentDetail';
 import DeploymentCreatePage from 'ee/containers/deploymentCreatePage';
 import DeploymentEditPage from 'ee/containers/deploymentEditPage';
 import GroupSettingsPage from 'containers/groupSettingsPage';
+import GroupSettingsDeployments from 'ee/components/groupSettings/deployments';
 import GroupSettingsMLflow from 'ee/components/groupSettings/mlflow';
 import NotebookViewer from 'containers/sharedFiles/notebookViewer';
 
@@ -51,6 +52,11 @@ class Main extends React.Component {
               <Route path={`${appPrefix}g/:groupName/settings`}>
                 <GroupSettingsPage
                   extraTabs={[
+                    {
+                      component: GroupSettingsDeployments,
+                      key: 'deployments',
+                      tab: 'Deployments',
+                    },
                     {
                       component: GroupSettingsMLflow,
                       key: 'mlflow',


### PR DESCRIPTION
Fixes
- [Bug] [CE] Don't show model deployment information in group settings (ch20718)
- [Bug] PrimeHub Deploy: There is no model deployment quota in group page. (ch20725)
- [User portal] the model deployment components should be displayed under Deployments tab only (ch20099)

Image: ch20718-74eab59
