### PR TITLE
fix(ui): use number as size instead of string

### DIFF
--- a/packages/client/src/components/apps/createForm.tsx
+++ b/packages/client/src/components/apps/createForm.tsx
@@ -514,7 +514,7 @@ class AppCreateForm extends React.Component<Props, State> {
               }
             </Form.Item>
           </Col>
-          <Col xs='24' sm='8' lg='8'>
+          <Col xs={24} sm={8} lg={8}>
             <ResourceMonitor
               selectedGroup={groupContext.id}
               groupContext={groupContext}

--- a/packages/client/src/containers/AppListContainer/index.tsx
+++ b/packages/client/src/containers/AppListContainer/index.tsx
@@ -269,7 +269,6 @@ class AppListContainer extends React.Component<Props, State> {
                     xs={24}
                     md={12}
                     xl={8}
-                    xxl={6}
                     key={edge.cursor}
                     style={{ marginBottom: 16 }}
                   >

--- a/packages/client/src/containers/appStore.tsx
+++ b/packages/client/src/containers/appStore.tsx
@@ -79,7 +79,7 @@ class AppStore extends React.Component<Props, State> {
       />
       <PageBody>
         <Row gutter={24} type='flex' style={{marginBottom: '16px'}}>
-          <Col xs={24} md={12} xl={12} xxl={8}>
+          <Col xs={24} md={12} xl={12}>
             <Search placeholder='Search application' onChange={ e => this.onSearch(e.currentTarget.value)} onSearch={this.onSearch}/>
           </Col>
         </Row>
@@ -106,7 +106,7 @@ class AppStore extends React.Component<Props, State> {
             {description.substr(descIndex + searchText.length)}
           </span> : description;
           return (
-            <Col xs={24} span={12} md={12} xxl={8} key={appTemplate.id} style={{marginBottom: 16}}>
+            <Col xs={24} span={12} md={12} xl={8} key={appTemplate.id} style={{marginBottom: 16}}>
               <Card style={{borderRadius: '4px'}}>
                 <Left>
                   <AppLogo src={appTemplate.icon} style={{marginRight: '8px'}}/>

--- a/packages/client/src/ee/components/job/createForm.tsx
+++ b/packages/client/src/ee/components/job/createForm.tsx
@@ -478,7 +478,7 @@ class CreateForm extends React.Component<Props, State> {
               }
             </Form.Item>
           </Col>
-          <Col xs="24" sm="8" lg="8">
+          <Col xs={24} sm={8} lg={8}>
             {
               showResources ? (
                 <ResourceMonitor

--- a/packages/client/src/ee/components/modelDeployment/createForm.tsx
+++ b/packages/client/src/ee/components/modelDeployment/createForm.tsx
@@ -579,7 +579,7 @@ class DeploymentCreateForm extends React.Component<Props, State> {
               }
             </Form.Item>
           </Col>
-          <Col xs="24" sm="8" lg="8">
+          <Col xs={24} sm={8} lg={8}>
             <ResourceMonitor
               selectedGroup={selectedGroup}
               groupContext={groupContext}

--- a/packages/client/src/ee/containers/DeploymentListContainer/index.tsx
+++ b/packages/client/src/ee/containers/DeploymentListContainer/index.tsx
@@ -288,7 +288,6 @@ function DeploymentListContainer({ groups, phDeployments, ...props }: Props) {
                   xs={24}
                   md={12}
                   xl={8}
-                  xxl={6}
                   key={edge.cursor}
                   style={{ marginBottom: 16 }}
                 >


### PR DESCRIPTION
## Screenshot

![Kapture 2021-09-09 at 16 53 43](https://user-images.githubusercontent.com/10325111/132655437-f1989ffb-db24-4fce-b3c9-b5d94d645379.gif)

## Descriptions

* Using number as size instead of string
* Removed `xxl` size due to not support. ([ref](https://3x.ant.design/components/grid/#components-grid-demo-responsive))

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed