### PR TITLE
Bug unable to clean up gpu url

### DIFF
--- a/packages/client/src/admin/Images/ImageForm.tsx
+++ b/packages/client/src/admin/Images/ImageForm.tsx
@@ -413,6 +413,7 @@ function _ImageForm({
                     }}
                   >
                     <Checkbox
+                      data-testid='enabled-imageUrlForGpu'
                       checked={enabledURLForGpu}
                       onChange={event =>
                         setEnabledURLForGpu(event.target.checked)

--- a/packages/client/src/admin/Images/ImageForm.tsx
+++ b/packages/client/src/admin/Images/ImageForm.tsx
@@ -250,7 +250,7 @@ function _ImageForm({
       }
     }
 
-    if (data?.urlForGpu) {
+    if (data?.type == 'both' && data?.urlForGpu !== data?.url) {
       setEnabledURLForGpu(true);
     }
 
@@ -302,6 +302,9 @@ function _ImageForm({
                 useImagePullSecret: enabledSelectSecret
                   ? values.useImagePullSecret
                   : null,
+                urlForGpu: values.type === 'both' && !enabledURLForGpu
+                  ? null
+                  : values.urlForGpu,
                 groups: {
                   // @ts-ignore
                   connect,
@@ -416,7 +419,9 @@ function _ImageForm({
                       }
                     />
                     {form.getFieldDecorator('urlForGpu', {
-                      initialValue: data?.urlForGpu || '',
+                      initialValue: enabledURLForGpu
+                        ? data?.urlForGpu || ''
+                        : '',
                     })(<Input disabled={!enabledURLForGpu} />)}
                   </div>
                 </Form.Item>


### PR DESCRIPTION
## Test image
ch20895-8f48f74

## repro steps
1. create an image with universal type
1. Container Image URL=cpu
1. Specific Container Image URL for GPU=gpu
1. click Confirm button
1. edit that image
1. uncheck the checkbox of "Specific Container Image URL for GPU"
1. click Confirm button
1. edit that image

## current behavior
1. the checkbox of "Specific Container Image URL for GPU" is checked
1. the field of "Specific Container Image URL for GPU" is still showing "gpu"

## expected behavior
1. it should restore to empty value