### PR TITLE
fix(models): add width to `deveployed by` field

### DIFF
--- a/packages/client/src/ee/containers/ModelDetail/index.tsx
+++ b/packages/client/src/ee/containers/ModelDetail/index.tsx
@@ -299,6 +299,7 @@ function ModelDetail({
       title: 'Deployed By',
       dataIndex: 'deployedBy',
       align: 'center',
+      width: '200px',
       render: (deployedBy: ModelVersion['deployedBy']) => {
         const tags = deployedBy.map((deploy, id) => (
           <Link key={id} to={`../deployments/${deploy.id}`}>


### PR DESCRIPTION
## Screenshots

<img width="1227" alt="截圖 2021-09-16 上午9 51 20" src="https://user-images.githubusercontent.com/10325111/133536568-5d0761d2-86aa-433d-8436-b9726936d9e8.png">

## Description

- When **parameters** field has many subfields, it squeezed the **developed by** field.

Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed