### PR TITLE
feat(me): add deployment counts field

### DIFF
--- a/packages/client/src/ee/components/shared/resourceMonitor.tsx
+++ b/packages/client/src/ee/components/shared/resourceMonitor.tsx
@@ -106,8 +106,13 @@ export default class ResourceMonitor extends React.Component<Props, State> {
                   </tr>
                   <tr>
                     <td>GPU</td>
-                    <td>{groupContext.resourceStatus.gpuUsage} </td>
+                    <td>{groupContext.resourceStatus.gpuUsage}</td>
                     <td>{groupContext.projectQuotaGpu == null ? '∞' : groupContext.projectQuotaGpu}</td>
+                  </tr>
+                  <tr>
+                    <td>Deployments</td>
+                    <td>{groupContext.deploymentsUsage}</td>
+                    <td>{groupContext.maxDeploy}</td>
                   </tr>
                 </tbody>
               </Table>

--- a/packages/client/src/ee/containers/deploymentCreatePage.tsx
+++ b/packages/client/src/ee/containers/deploymentCreatePage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import gql from 'graphql-tag';
-import { Alert, notification } from 'antd';
+import { notification } from 'antd';
 import { graphql } from 'react-apollo';
 import { compose } from 'recompose';
 import { get, unionBy, pick } from 'lodash';
@@ -10,7 +10,6 @@ import { withRouter } from 'react-router-dom';
 import { errorHandler } from 'utils/errorHandler';
 import DeploymentCreateForm from 'ee/components/modelDeployment/createForm';
 import PageTitle from 'components/pageTitle';
-import PageBody from 'components/pageBody';
 import { GroupContextComponentProps, withGroupContext } from 'context/group';
 import Breadcrumbs from 'components/share/breadcrumb';
 import { sortNameByAlphaBet } from 'utils/sorting';
@@ -50,59 +49,6 @@ type Props = RouteComponentProps & GroupContextComponentProps & {
 type State = {
   selectedGroup: string | null;
 };
-
-function renderReachedDeploymentLimitAlert({
-  isReachedGroupDeploymentsLimit,
-  isReachedSystemDeploymentsLimit,
-}: {
-  isReachedGroupDeploymentsLimit: boolean;
-  isReachedSystemDeploymentsLimit: boolean;
-}) {
-  const REACHED_DEPLOYMENTS_LIMIT_MESSAGES = {
-    group: (
-      <PageBody>
-        <Alert
-          message="The group deployment limit has been reached."
-          description="Please get in touch with your system administrator to increase the group deployment limit or delete one of your current deployments to deploy a new model."
-          type="error"
-          showIcon
-        />
-      </PageBody>
-    ),
-    system: (
-      <PageBody>
-        <Alert
-          message="The system deployment limit has been reached."
-          description="Please get in touch with your system administrator to update the license or delete one of the group’s deployments to deploy a new model."
-          type="error"
-          showIcon
-        />
-      </PageBody>
-    ),
-    both: (
-      <PageBody>
-        <Alert
-          message="Both system deployment limit and group deployment limit has been reached."
-          description="Please get in touch with your system administrator to update the license and increase the group deployment limit, or delete one of the group’s deployments to deploy a new model."
-          type="error"
-          showIcon
-        />
-      </PageBody>
-    ),
-  };
-
-  if (isReachedGroupDeploymentsLimit && isReachedSystemDeploymentsLimit) {
-    return REACHED_DEPLOYMENTS_LIMIT_MESSAGES['system'];
-  }
-
-  if (isReachedGroupDeploymentsLimit && !isReachedSystemDeploymentsLimit) {
-    return REACHED_DEPLOYMENTS_LIMIT_MESSAGES['group'];
-  }
-
-  if (isReachedGroupDeploymentsLimit && isReachedSystemDeploymentsLimit) {
-    return REACHED_DEPLOYMENTS_LIMIT_MESSAGES['both'];
-  }
-}
 
 class DeploymentCreatePage extends React.Component<Props, State> {
   state = {
@@ -165,11 +111,6 @@ class DeploymentCreatePage extends React.Component<Props, State> {
           title={'Create Deployment'}
         />
 
-        {renderReachedDeploymentLimitAlert({
-          isReachedGroupDeploymentsLimit,
-          isReachedSystemDeploymentsLimit,
-        })}
-
         <div style={{ margin: '16px' }}>
           <DeploymentCreateForm
             type="create"
@@ -183,6 +124,8 @@ class DeploymentCreatePage extends React.Component<Props, State> {
             initialValue={initValue}
             onSubmit={this.onSubmit}
             loading={currentUser.loading || createPhDeploymentResult.loading}
+            isReachedGroupDeploymentsLimit={isReachedGroupDeploymentsLimit}
+            isReachedSystemDeploymentsLimit={isReachedSystemDeploymentsLimit}
           />
         </div>
       </React.Fragment>

--- a/packages/client/src/ee/containers/deploymentEditPage.tsx
+++ b/packages/client/src/ee/containers/deploymentEditPage.tsx
@@ -32,6 +32,7 @@ type Props = RouteComponentProps<{deploymentId: string}> & GroupContextComponent
   updatePhDeployment: any;
   updatePhDeploymentResult: any;
   getPhDeployment: any;
+  licenseQuery: any;
 };
 
 type State = {
@@ -136,6 +137,12 @@ class DeploymentCreatePage extends React.Component<Props, State> {
       }
     } catch(e) {}
 
+    const isReachedGroupDeploymentsLimit =
+      group?.deployments >= group?.maxpGroup;
+    const isReachedSystemDeploymentsLimit =
+      this.props.licenseQuery?.license.usage.maxModelDeploy >=
+      this.props.licenseQuery?.license.maxModelDeploy;
+
     return (
       <React.Fragment>
         <PageTitle
@@ -159,6 +166,8 @@ class DeploymentCreatePage extends React.Component<Props, State> {
             onSubmit={this.onSubmit}
             onCancel={this.onCancel}
             loading={currentUser.loading || updatePhDeploymentResult.loading}
+            isReachedGroupDeploymentsLimit={isReachedGroupDeploymentsLimit}
+            isReachedSystemDeploymentsLimit={isReachedSystemDeploymentsLimit}
           />
         </div>
       </React.Fragment>
@@ -173,6 +182,21 @@ export default compose(
     alias: 'withCurrentUser',
     name: 'currentUser'
   }),
+  graphql(
+    gql`
+      query {
+        license {
+          maxModelDeploy
+          usage {
+            maxModelDeploy
+          }
+        }
+      }
+    `,
+    {
+      name: 'licenseQuery',
+    }
+  ),
   graphql(GET_PH_DEPLOYMENT, {
     options: (props: Props) => ({
       variables: {

--- a/packages/client/src/fakeData/me.ts
+++ b/packages/client/src/fakeData/me.ts
@@ -15,6 +15,7 @@ export const me = {
       projectQuotaGpu: null,
       projectQuotaMemory: null,
       maxDeploy: 10,
+      deploymentsUsage: 5,
       datasets: [],
       resourceStatus: {
         cpuUsage: 0,
@@ -85,6 +86,7 @@ export const me = {
       projectQuotaGpu: null,
       projectQuotaMemory: null,
       maxDeploy: 10,
+      deploymentsUsage: 5,
       datasets: null,
       resourceStatus: {
         cpuUsage: 1,
@@ -143,6 +145,7 @@ export const me = {
       projectQuotaGpu: null,
       projectQuotaMemory: null,
       maxDeploy: 10,
+      deploymentsUsage: 5,
       datasets: null,
       resourceStatus: null,
       enabledDeployment: null,

--- a/packages/client/src/queries/fragments/GroupInfo.graphql
+++ b/packages/client/src/queries/fragments/GroupInfo.graphql
@@ -58,6 +58,7 @@ fragment GroupInfo on Group {
   }
   enabledDeployment
   maxDeploy
+  deploymentsUsage
   enabledSharedVolume
   jobDefaultActiveDeadlineSeconds
   sharedVolumeCapacity

--- a/packages/graphql-server/src/graphql/group.graphql
+++ b/packages/graphql-server/src/graphql/group.graphql
@@ -48,6 +48,7 @@ type Group {
   # enabledDeployment
   enabledDeployment: Boolean
   maxDeploy: Int
+  deploymentsUsage: Int
   jobDefaultActiveDeadlineSeconds: Int
   # group admin
   admins: String

--- a/packages/graphql-server/src/resolvers/group.ts
+++ b/packages/graphql-server/src/resolvers/group.ts
@@ -54,6 +54,7 @@ const attrSchema = {
   launchGroupOnly: {type: FieldType.boolean, rename: 'launch-group-only'},
   enabledDeployment: {type: FieldType.boolean, rename: 'enabled-deployment'},
   maxDeploy: {type: FieldType.integer, rename: 'max-deploy'},
+  deploymentsUsage: { type: FieldType.integer },
   jobDefaultActiveDeadlineSeconds: {type: FieldType.integer, rename: 'job-default-active-deadline-seconds'},
   // group admin
   admins: {serialize: splitByComma, deserialize: joinByComma},


### PR DESCRIPTION
## Screenshots

### Monitor
<img width="403" alt="截圖 2021-09-15 下午3 30 22" src="https://user-images.githubusercontent.com/10325111/133537885-1b972c96-c3bf-4063-8647-ae192a82efb5.png">

### Reached Deployment Limit

<img width="1207" alt="截圖 2021-09-22 上午8 24 13" src="https://user-images.githubusercontent.com/10325111/134264602-eadec369-215a-448c-a54e-684e89505429.png">

## Descriptions

- Added `deploymentsUsage` field into group
- Added deployments information into resource monitor
- Added reach deployments limit alert information

Signed-off-by: Jie Peng <im@jiepeng.me><!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed