### PR TITLE
fix(image): check custom image is configured

### DIFF
--- a/packages/client/src/@types/global.d.ts
+++ b/packages/client/src/@types/global.d.ts
@@ -12,7 +12,7 @@ declare global {
     enableCustomImage?: boolean;
     disableMode?: boolean;
     disableGroup?: boolean;
-    customImageSetup?: boolean;
+    customImageSetup?: string;
     enableUploadServer?: boolean;
     disableEnableSharedVolume?: boolean;
     isUserAdmin?: boolean;

--- a/packages/client/src/admin/Images/ImageForm.tsx
+++ b/packages/client/src/admin/Images/ImageForm.tsx
@@ -262,7 +262,10 @@ function _ImageForm({
   }, [data]);
 
   useEffect(() => {
-    if (window.customImageSetup) {
+    if (
+      window.enableCustomImage &&
+      window.customImageSetup?.toLowerCase() === 'true'
+    ) {
       setIsRegistyConfigured(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/client/src/admin/Images/__tests__/ImageAdd.spec.tsx
+++ b/packages/client/src/admin/Images/__tests__/ImageAdd.spec.tsx
@@ -26,12 +26,14 @@ beforeEach(() => {
   // @ts-ignore
   global.modelDeploymentOnly = false;
   // @ts-ignore
-  global.customImageSetup = true;
+  global.customImageSetup = 'true';
+  // @ts-ignore
+  global.enableCustomImage = true;
 });
 
 afterEach(() => {
   // @ts-ignore
-  global.customImageSetup = false;
+  global.customImageSetup = 'false';
 });
 
 describe('ImageAdd', () => {
@@ -82,7 +84,24 @@ describe('ImageAdd', () => {
 
   it('should render create image with disabled custom build image option', () => {
     // @ts-ignore
-    global.customImageSetup = false;
+    global.customImageSetup = 'false';
+    const { TestProvider } = setup();
+
+    render(
+      <TestProvider>
+        <MockedProvider>
+          <ImageAdd />
+        </MockedProvider>
+      </TestProvider>
+    );
+
+    expect(screen.getByTestId('custom-image')).toHaveAttribute('disabled');
+    expect(true).toBe(true);
+  });
+
+  it('should disabled custom build image option when `enableCustomImage` is disabled', () => {
+    // @ts-ignore
+    global.enableCustomImage = false;
     const { TestProvider } = setup();
 
     render(

--- a/packages/client/src/components/images/createForm.tsx
+++ b/packages/client/src/components/images/createForm.tsx
@@ -21,7 +21,9 @@ const StyledFormItem = styled(Form.Item)`
   }
 `;
 
-const DISABLE_BUILD_IMAGE = !window.customImageSetup;
+const DISABLE_BUILD_IMAGE =
+  !window.enableCustomImage &&
+  window.customImageSetup?.toLowerCase() !== 'false';
 
 enum FormType {
   Edit = 'edit',

--- a/packages/client/src/containers/__tests__/imageCreatePage.spec.tsx
+++ b/packages/client/src/containers/__tests__/imageCreatePage.spec.tsx
@@ -35,6 +35,8 @@ const AllTheProviders = ({ children }) => {
 
 describe('ImageCreateForm Container', () => {
   it('Should render create page properly', async () => {
+    // @ts-ignore
+    global.customImageSetup = 'true';
     render(<ImageCreatePage />, { wrapper: AllTheProviders });
     expect(await screen.findByText('Container Image URL')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Screenshots

<img width="1409" alt="截圖 2021-10-13 上午11 21 46" src="https://user-images.githubusercontent.com/10325111/137234272-36c8df3b-ab85-453d-bd9d-50e1ddca75d7.png">

## Descriptions

- Fixed custom build image disabled if the registry did not configuration.

## Image

- sc19426-24d0efc8

Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed