### PR TITLE
[Bug] Build custom image is not enabled in CE

### DIFF
--- a/packages/admin-server/src/config.ts
+++ b/packages/admin-server/src/config.ts
@@ -43,9 +43,7 @@ export interface Config {
   readOnlyOnInstanceTypeAndImage?: boolean;
   enableDatasetUpload: boolean;
 
-  // image builder
-  // TODO: need rename variable to image builder for consistently
-  enableCustomImage: boolean;
+  // custom image
   // image builder should have registry setup, use env.PRIMEHUB_CUSTOM_IMAGE_REGISTRY_ENDPOINT to determine it.
   customImageSetup: boolean;
 
@@ -102,7 +100,6 @@ const defaultConfigs = {
   enableUserPortal: false,
   readOnlyOnInstanceTypeAndImage: false,
   enableDatasetUpload: false,
-  enableCustomImage: false,
   enableMaintenanceNotebook: false,
   enableUsageReport: false,
   enableGrafana: false,
@@ -178,7 +175,6 @@ export const createConfig = (): Config => {
     primehubVersion: process.env.PH_VERSION,
     // Feature Flags
     enableDatasetUpload: getEnvBoolean('PRIMEHUB_FEATURE_DATASET_UPLOAD', false),
-    enableCustomImage: getEnvBoolean('PRIMEHUB_FEATURE_CUSTOM_IMAGE', false),
     enableMaintenanceNotebook: getEnvBoolean('PRIMEHUB_FEATURE_MAINTENANCE_NOTEBOOK', false),
     enableGrafana: getEnvBoolean('PRIMEHUB_FEATURE_GRAFANA', false),
     enableUsageReport: getEnvBoolean('PRIMEHUB_FEATURE_USAGE', false),

--- a/packages/admin-server/src/createEnvVariablesSetup.ts
+++ b/packages/admin-server/src/createEnvVariablesSetup.ts
@@ -14,7 +14,6 @@ const createEnvVariablesSetup = () => (ctx: Context, next: Next) => {
     : '/oidc/request-api-token';
   ctx.state.disableMode = config.readOnlyOnInstanceTypeAndImage;
   ctx.state.enableDatasetUpload = config.enableDatasetUpload;
-  ctx.state.enableCustomImage = config.enableCustomImage;
   ctx.state.enableMaintenanceNotebook = config.enableMaintenanceNotebook;
   ctx.state.enableGrafana = config.enableGrafana;
   ctx.state.enableUsageReport = config.enableUsageReport;

--- a/packages/client/public/index.ejs
+++ b/packages/client/public/index.ejs
@@ -139,7 +139,7 @@
       window.newAccessToken = '<%= newAccessToken %>';
       window.requestApiTokenEndpoint = '<%= requestApiTokenEndpoint %>';
       window.jobDefaultActiveDeadlineSeconds = <%= jobDefaultActiveDeadlineSeconds %>;
-      window.customImageSetup = '<%= customImageSetup %>';
+      window.customImageSetup = <%= customImageSetup %>;
       window.primehubVersion = '<%= primehubVersion %>';
       window.apiToken = '<%= apiToken %>';
       window.disableMode = <%= disableMode %>;
@@ -152,7 +152,6 @@
       window.enableJobArtifact = <%= enableJobArtifact %>;
       window.enableJobMonitoring = <%= enableJobMonitoring %>;
       window.enableApp = <%= enableApp %>;
-      window.enableCustomImage = <%= enableCustomImage%>;
       window.enableUsageReport = <%= enableUsageReport%>;
       window.enableGrafana = <%= enableGrafana %>;
       window.enableLicenseCheck = <%= enableLicenseCheck %>;

--- a/packages/client/public/index.html
+++ b/packages/client/public/index.html
@@ -15,7 +15,6 @@
     } else {
       window.APP_PREFIX = '/';
       window.development = true;
-      window.enableCustomImage = true;
       window.isUserAdmin = true;
       window.customImageSetup = true;
       window.enableLogPersistence = true;

--- a/packages/client/src/admin/Images/ImageForm.tsx
+++ b/packages/client/src/admin/Images/ImageForm.tsx
@@ -262,10 +262,7 @@ function _ImageForm({
   }, [data]);
 
   useEffect(() => {
-    if (
-      window.enableCustomImage &&
-      window.customImageSetup?.toLowerCase() === 'true'
-    ) {
+    if (window.customImageSetup) {
       setIsRegistyConfigured(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/client/src/admin/Images/__tests__/ImageAdd.spec.tsx
+++ b/packages/client/src/admin/Images/__tests__/ImageAdd.spec.tsx
@@ -26,14 +26,12 @@ beforeEach(() => {
   // @ts-ignore
   global.modelDeploymentOnly = false;
   // @ts-ignore
-  global.customImageSetup = 'true';
-  // @ts-ignore
-  global.enableCustomImage = true;
+  global.customImageSetup = true;
 });
 
 afterEach(() => {
   // @ts-ignore
-  global.customImageSetup = 'false';
+  global.customImageSetup = false;
 });
 
 describe('ImageAdd', () => {
@@ -84,7 +82,7 @@ describe('ImageAdd', () => {
 
   it('should render create image with disabled custom build image option', () => {
     // @ts-ignore
-    global.customImageSetup = 'false';
+    global.customImageSetup = false;
     const { TestProvider } = setup();
 
     render(
@@ -99,9 +97,9 @@ describe('ImageAdd', () => {
     expect(true).toBe(true);
   });
 
-  it('should disabled custom build image option when `enableCustomImage` is disabled', () => {
+  it('should disabled custom build image option when `customImageSetup` is disabled', () => {
     // @ts-ignore
-    global.enableCustomImage = false;
+    global.customImageSetup = false;
     const { TestProvider } = setup();
 
     render(

--- a/packages/client/src/components/images/createForm.tsx
+++ b/packages/client/src/components/images/createForm.tsx
@@ -21,9 +21,7 @@ const StyledFormItem = styled(Form.Item)`
   }
 `;
 
-const DISABLE_BUILD_IMAGE =
-  !window.enableCustomImage &&
-  window.customImageSetup?.toLowerCase() !== 'false';
+const DISABLE_BUILD_IMAGE = !window.customImageSetup;
 
 enum FormType {
   Edit = 'edit',

--- a/packages/client/src/containers/__tests__/imageCreatePage.spec.tsx
+++ b/packages/client/src/containers/__tests__/imageCreatePage.spec.tsx
@@ -36,7 +36,7 @@ const AllTheProviders = ({ children }) => {
 describe('ImageCreateForm Container', () => {
   it('Should render create page properly', async () => {
     // @ts-ignore
-    global.customImageSetup = 'true';
+    global.customImageSetup = true;
     render(<ImageCreatePage />, { wrapper: AllTheProviders });
     expect(await screen.findByText('Container Image URL')).toBeInTheDocument();
   });


### PR DESCRIPTION
Fix "Build custom image" is not enabled in CE

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**Special notes for your reviewer**:
The concept of the fix it

1. The custom image is always enabled, so i removed this `enableCustomImage` flag
2. Only show warning if the registry is not setup.

## Test image
`sc22334-08618ce`