### PR TITLE
feat(system): add max node info and update field name

### DIFF
--- a/packages/client/src/admin/SystemSetting/SystemSetting.tsx
+++ b/packages/client/src/admin/SystemSetting/SystemSetting.tsx
@@ -296,7 +296,7 @@ function _SystemSetting({ form, data, ...props }: Props) {
                 </Col>
                 <Col sm={5} xs={24}>
                   <div>
-                    <CustomLabel>Utilized Nodes</CustomLabel>
+                    <CustomLabel>Nodes</CustomLabel>
                     <div data-testid='license-maxNode'>
                       {get(license, 'usage.maxNode', 0)}/
                       {Number(license.maxNode) === -1 ? '∞' : license.maxNode}
@@ -305,7 +305,16 @@ function _SystemSetting({ form, data, ...props }: Props) {
                 </Col>
                 <Col sm={5} xs={24}>
                   <div>
-                    <CustomLabel>Deployed Models</CustomLabel>
+                    <CustomLabel>Groups</CustomLabel>
+                    <div data-testid='license-maxGroup'>
+                      {get(license, 'usage.maxGroup', 0)}/
+                      {Number(license.maxGroup) === -1 ? '∞' : license.maxGroup}
+                    </div>
+                  </div>
+                </Col>
+                <Col sm={5} xs={24}>
+                  <div>
+                    <CustomLabel>Deployments</CustomLabel>
                     <div data-testid='license-maxDeploy'>
                       {get(license, 'usage.maxModelDeploy', 0)}/
                       {Number(license.maxModelDeploy) === -1

--- a/packages/client/src/admin/SystemSetting/__tests__/SystemSetting.spec.tsx
+++ b/packages/client/src/admin/SystemSetting/__tests__/SystemSetting.spec.tsx
@@ -127,6 +127,9 @@ describe('SystemSetting', () => {
     expect(await screen.findByTestId('license-maxDeploy')).toHaveTextContent(
       '109/1000'
     );
+    expect(await screen.findByTestId('license-maxGroup')).toHaveTextContent(
+      '68/9999'
+    );
   });
 
   it('[Settings] should render system setting with fetched data', async () => {


### PR DESCRIPTION
## Screenshot

<img width="1410" alt="截圖 2021-10-22 下午3 51 55" src="https://user-images.githubusercontent.com/10325111/138417708-52506486-ebf2-4c74-9a43-347d5606deb9.png">

## Descriptions

- Showing group information.

## Image

- sc21270-1df66a96

Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed