### PR TITLE
Prevent null data when job monitoring disabled

### DIFF
--- a/packages/client/src/ee/containers/jobMonitoring.tsx
+++ b/packages/client/src/ee/containers/jobMonitoring.tsx
@@ -91,17 +91,18 @@ class JobMonitoringContainer extends React.Component<Props> {
   }
 
   shouldComponentUpdate = (nextProps, nextState) => {
+    if (!this.props.data || !nextProps.data) {
+      return false;
+    }
     if ((!this.props.data.phJob && nextProps.data.phJob) || (this.props.data.phJob && nextProps.data.phJob && this.state.period === null)) {
       this.state.period = Object.keys(periods)[0];
       return true;
     }
     if (this.state.period !== nextState.period) { return true; }
-    if (nextProps.data.phJob
-      && nextProps.data.phJob.monitoring
-      && nextProps.data.phJob.monitoring.datasets
-      && this.props.data.phJob
-      && this.props.data.phJob.monitoring
-      && this.props.data.phJob.monitoring.datasets) {
+    if (
+      nextProps.data?.phJob?.monitoring?.datasets &&
+      this.props.data?.phJob?.monitoring?.datasets
+    ) {
       const period = this.state.period;
       const thisDatasets = this.props.data.phJob.monitoring.datasets;
       const nextDatasets = nextProps.data.phJob.monitoring.datasets;


### PR DESCRIPTION
Signed-off-by: Timothy Lee <ctiml@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
Prevent job monitoring tab from getting blank page when monitoring feature disabled

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
![螢幕錄製 2021-10-26 09 11 52](https://user-images.githubusercontent.com/3894670/138792392-da6c816b-b786-4928-ba59-9d22d0a0defa.gif)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
