### PR TITLE
fix(shareFile): remove duplicate download button

### DIFF
--- a/packages/client/src/containers/sharedFiles/BrowseSharedFiles.tsx
+++ b/packages/client/src/containers/sharedFiles/BrowseSharedFiles.tsx
@@ -223,10 +223,6 @@ function ShareFileActions({
     actions.push(ViewFile);
   }
 
-  if (/\.([a-zA-Z]+)$/i.test(props.name)) {
-    actions.push(DownloadFile);
-  }
-
   if (props.name.endsWith('ipynb')) {
     actions.push(
       <Menu.Item
@@ -238,6 +234,9 @@ function ShareFileActions({
         View file
       </Menu.Item>
     );
+  }
+
+  if (/\.([a-zA-Z]+)$/i.test(props.name)) {
     actions.push(DownloadFile);
   }
 


### PR DESCRIPTION
## Screenshots

| Before | After |
| ------ | ----- |
|<img width="1193" alt="截圖 2021-11-04 下午2 50 19" src="https://user-images.githubusercontent.com/10325111/140271306-06edbd5d-3bf0-4aa1-88bf-feff4384d85e.png">|<img width="1183" alt="截圖 2021-11-04 下午2 56 52" src="https://user-images.githubusercontent.com/10325111/140271320-cd16999b-5a3f-4539-92a4-ea1d286a1677.png">|

## Descriptions

- Removing duplicate download button

## Image

- `sc22822-cc4c4819`

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed


Signed-off-by: Jie Peng <im@jiepeng.me>
