### PR TITLE
fix(instanceType): adding CTA buttons for each tab

### DIFF
--- a/packages/client/src/admin.tsx
+++ b/packages/client/src/admin.tsx
@@ -63,7 +63,6 @@ export const tokenSyncWorker = new BackgroundTokenSyncer({
       placement: 'bottomRight',
       duration: null,
       btn: (
-        // @ts-ignore
         <Button
           type='primary'
           onClick={() => window.location.replace(`${appPrefix}oidc/logout`)}

--- a/packages/client/src/admin/Group/GroupList.tsx
+++ b/packages/client/src/admin/Group/GroupList.tsx
@@ -251,7 +251,6 @@ export function GroupList(props: Props) {
             alignItems: 'flex-end',
           }}
         >
-          {/* @ts-ignore */}
           <InfuseButton
             data-testid='add-button'
             icon='plus'

--- a/packages/client/src/admin/Images/ImageForm.tsx
+++ b/packages/client/src/admin/Images/ImageForm.tsx
@@ -627,10 +627,10 @@ function _ImageForm({
         <div
           style={{ display: 'flex', gap: '16px', justifyContent: 'flex-end' }}
         >
-          {/* @ts-ignore */}
           <Button type='primary' htmlType='submit' data-testid='confirm-button'>
             Confirm
           </Button>
+
           <Button
             data-testid='reset-button'
             onClick={() => {
@@ -713,7 +713,6 @@ function _ImageForm({
                     justifyContent: 'flex-end',
                   }}
                 >
-                  {/* @ts-ignore */}
                   <Button
                     type='primary'
                     onClick={() => {
@@ -765,7 +764,6 @@ function _ImageForm({
                     justifyContent: 'flex-end',
                   }}
                 >
-                  {/* @ts-ignore */}
                   <Button
                     type='primary'
                     onClick={() => setBuildDetailVisible(false)}

--- a/packages/client/src/admin/Images/ImageList.tsx
+++ b/packages/client/src/admin/Images/ImageList.tsx
@@ -210,7 +210,6 @@ function _ImageList({ data, ...props }: ImageListProps) {
       <div style={styles}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
           <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            {/* @ts-ignore */}
             <Button
               data-testid='add-button'
               type='primary'

--- a/packages/client/src/admin/InstanceTypes/InstanceTypeForm.tsx
+++ b/packages/client/src/admin/InstanceTypes/InstanceTypeForm.tsx
@@ -315,15 +315,33 @@ export function _InstanceTypeForm({
 
           form.validateFields((err, values: InstanceTypeFormState) => {
             if (err) {
-              let errorMessages = '';
+              const fieldsMap = {
+                nodeList: 'Node Selector',
+              };
+
+              const errorMessages = [];
               Object.keys(err).map(key => {
-                errorMessages += `${get(err, `${key}.errors[0].message`)}\n`;
+                if (Array.isArray(get(err, `${key}`))) {
+                  errorMessages.push(
+                    <>
+                      🔸 {fieldsMap[key] ?? key} has errors
+                      <br />
+                    </>
+                  );
+                } else {
+                  errorMessages.push(
+                    <>
+                      🔸 {get(err, `${key}.errors[0].message`)}
+                      <br />
+                    </>
+                  );
+                }
               });
 
               notification.error({
                 duration: 5,
                 placement: 'bottomRight',
-                message: `Failure`,
+                message: `Failure to create instance`,
                 description: errorMessages,
               });
 

--- a/packages/client/src/admin/InstanceTypes/InstanceTypeForm.tsx
+++ b/packages/client/src/admin/InstanceTypes/InstanceTypeForm.tsx
@@ -5,7 +5,6 @@ import {
   Form,
   Input,
   InputNumber,
-  Icon,
   Popconfirm,
   Spin,
   Switch,
@@ -392,7 +391,6 @@ export function _InstanceTypeForm({
                       min={0}
                       precision={1}
                       step={0.5}
-                      // @ts-ignore
                       parser={value => value.replace(/[^0-9.]/g, '')}
                       style={{ width: '105px' }}
                     />
@@ -419,7 +417,6 @@ export function _InstanceTypeForm({
                       precision={1}
                       step={1}
                       formatter={value => `${value} GB`}
-                      // @ts-ignore
                       parser={value => value.replace(/[^0-9.]/g, '')}
                       style={{ width: '105px' }}
                     />
@@ -546,7 +543,6 @@ export function _InstanceTypeForm({
 
                           return null;
                         }}
-                        // @ts-ignore
                         parser={value => value.replace(/[^0-9.]/g, '')}
                         disabled={!advanceFeature.enableMemoryRequest}
                         style={{ marginLeft: '8px', width: '130px' }}
@@ -621,7 +617,6 @@ export function _InstanceTypeForm({
                 marginBottom: '16px',
               }}
             >
-              {/* @ts-ignore */}
               <Button
                 data-testid='create-toleration'
                 type='primary'
@@ -764,7 +759,6 @@ export function _InstanceTypeForm({
               </Button>
 
               <div style={{ display: 'flex', gap: '16px' }}>
-                {/* @ts-ignore */}
                 <Button
                   data-testid='confirm-button'
                   type='primary'

--- a/packages/client/src/admin/InstanceTypes/InstanceTypeForm.tsx
+++ b/packages/client/src/admin/InstanceTypes/InstanceTypeForm.tsx
@@ -120,13 +120,42 @@ type UserGroupsAction =
   | { type: 'GROUPS'; groups: Groups[] }
   | { type: 'CONNECTIONS'; connect: Groups[]; disconnect: Groups[] };
 
+function FormButtons() {
+  const history = useHistory();
+  const { appPrefix } = useRoutePrefix();
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        marginTop: '24px',
+        justifyContent: 'flex-end',
+        gap: '8px',
+      }}
+    >
+      <div style={{ display: 'flex', gap: '16px' }}>
+        <Button data-testid='confirm-button' type='primary' htmlType='submit'>
+          Confirm
+        </Button>
+        <Button
+          data-testid='reset-button'
+          onClick={() => {
+            history.push(`${appPrefix}admin/instanceType`);
+          }}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function _InstanceTypeForm({
   loading = false,
   form,
   data,
   ...props
 }: InstanceTypeFormProps) {
-  const [activePanel, setActivePanel] = React.useState('1');
   const [tolerations, setTolerations] = React.useState([]);
   const [nodeList, setNodeList] = React.useState<string[][]>([]);
   const [globalStatus, setGlobalStatus] = React.useState(true);
@@ -333,7 +362,7 @@ export function _InstanceTypeForm({
           });
         }}
       >
-        <Tabs activeKey={activePanel} onTabClick={tab => setActivePanel(tab)}>
+        <Tabs>
           {/* Basic */}
           <Tabs.TabPane tab='Basic Info' key='1'>
             <Spin spinning={loading}>
@@ -592,20 +621,10 @@ export function _InstanceTypeForm({
                     />
                   </Form.Item>
                 )}
-
-                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                  <Button
-                    data-testid='next1-button'
-                    icon='arrow-right'
-                    onClick={() =>
-                      setActivePanel(prev => String(Number(prev) + 1))
-                    }
-                  >
-                    Next
-                  </Button>
-                </div>
               </div>
             </Spin>
+
+            <FormButtons />
           </Tabs.TabPane>
 
           {/* Tolerations */}
@@ -707,28 +726,7 @@ export function _InstanceTypeForm({
               />
             )}
 
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'flex-end',
-                marginTop: '16px',
-                gap: '8px',
-              }}
-            >
-              <Button
-                icon='arrow-left'
-                onClick={() => setActivePanel(prev => String(Number(prev) - 1))}
-              >
-                Basic Info
-              </Button>
-              <Button
-                data-testid='next2-button'
-                icon='arrow-right'
-                onClick={() => setActivePanel(prev => String(Number(prev) + 1))}
-              >
-                Next
-              </Button>
-            </div>
+            <FormButtons />
           </Tabs.TabPane>
 
           {/* Node Selector */}
@@ -743,39 +741,7 @@ export function _InstanceTypeForm({
               />
             )}
 
-            <div
-              style={{
-                display: 'flex',
-                marginTop: '24px',
-                justifyContent: 'space-between',
-                gap: '8px',
-              }}
-            >
-              <Button
-                icon='arrow-left'
-                onClick={() => setActivePanel(prev => String(Number(prev) - 1))}
-              >
-                Tolerations
-              </Button>
-
-              <div style={{ display: 'flex', gap: '16px' }}>
-                <Button
-                  data-testid='confirm-button'
-                  type='primary'
-                  htmlType='submit'
-                >
-                  Confirm
-                </Button>
-                <Button
-                  data-testid='reset-button'
-                  onClick={() => {
-                    history.push(`${appPrefix}admin/instanceType`);
-                  }}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </div>
+            <FormButtons />
           </Tabs.TabPane>
 
           {form.getFieldDecorator('id', {

--- a/packages/client/src/admin/InstanceTypes/InstanceTypes.tsx
+++ b/packages/client/src/admin/InstanceTypes/InstanceTypes.tsx
@@ -341,7 +341,6 @@ export function _InstanceTypes({
       <div style={styles}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
           <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            {/* @ts-ignore */}
             <Button
               data-testid='add-button'
               type='primary'

--- a/packages/client/src/admin/InstanceTypes/NodeSelectorList.tsx
+++ b/packages/client/src/admin/InstanceTypes/NodeSelectorList.tsx
@@ -49,7 +49,6 @@ export function NodeSelectorList({
       )}
 
       <div style={{ display: 'flex', justifyContent: 'center' }}>
-        {/* @ts-ignore */}
         <Button
           data-testid='add-field-button'
           type='dashed'

--- a/packages/client/src/admin/InstanceTypes/TolerationModalForm.tsx
+++ b/packages/client/src/admin/InstanceTypes/TolerationModalForm.tsx
@@ -23,7 +23,9 @@ export function TolerationModalForm({
 }: Props) {
   const disabledOK =
     !currentToleration?.key ||
-    (currentToleration?.operator === 'Equal' && !currentToleration?.value);
+    (currentToleration?.operator === 'Equal' && !currentToleration?.value) ||
+    props.form.getFieldError('toleration-key')?.length > 0 ||
+    false;
 
   React.useEffect(() => {
     if (type === 'create') {
@@ -35,6 +37,7 @@ export function TolerationModalForm({
   return (
     <Modal
       title={type ? 'Create Toleration' : 'Edit Toleration'}
+      maskClosable={false}
       visible={visible}
       okButtonProps={{ disabled: disabledOK }}
       onOk={() => props.onOk()}

--- a/packages/client/src/admin/Secrets/Secrets.tsx
+++ b/packages/client/src/admin/Secrets/Secrets.tsx
@@ -245,7 +245,6 @@ function _Secrets({
               data-testid='add-button'
               type='primary'
               icon='plus'
-              // @ts-ignore
               disabled={secretQuery.loading}
               onClick={() =>
                 history.push(`${appPrefix}admin/secret?operator=create`)

--- a/packages/client/src/admin/SystemSetting/SystemSetting.tsx
+++ b/packages/client/src/admin/SystemSetting/SystemSetting.tsx
@@ -630,7 +630,7 @@ function _SystemSetting({ form, data, ...props }: Props) {
           >
             Reset
           </Button>
-          {/* @ts-ignore */}
+
           <Button type='primary' htmlType='submit' form='system-settings'>
             Confirm
           </Button>

--- a/packages/client/src/containers/AppListContainer/index.tsx
+++ b/packages/client/src/containers/AppListContainer/index.tsx
@@ -236,7 +236,7 @@ class AppListContainer extends React.Component<Props, State> {
               App Settings
             </a>
           )}
-          {/* @ts-ignore */}
+
           <InfuseButton
             icon='plus'
             type='primary'

--- a/packages/client/src/ee/components/job/list.tsx
+++ b/packages/client/src/ee/components/job/list.tsx
@@ -390,7 +390,6 @@ class JobList extends React.Component<Props> {
               alignItems: 'flex-end',
             }}
           >
-            {/* @ts-ignore */}
             <InfuseButton
               icon='plus'
               onClick={this.createPhJob}
@@ -399,7 +398,6 @@ class JobList extends React.Component<Props> {
             >
               New Job
             </InfuseButton>
-            {/* @ts-ignore */}
             <InfuseButton onClick={this.refresh}>Refresh</InfuseButton>
           </div>
           <Filter

--- a/packages/client/src/ee/containers/DeploymentListContainer/index.tsx
+++ b/packages/client/src/ee/containers/DeploymentListContainer/index.tsx
@@ -227,7 +227,7 @@ function DeploymentListContainer({ groups, phDeployments, ...props }: Props) {
           >
             Refresh
           </InfuseButton>
-          {/* @ts-ignore */}
+
           <InfuseButton
             icon='plus'
             type='primary'

--- a/packages/client/src/ee/main.model_deploy.tsx
+++ b/packages/client/src/ee/main.model_deploy.tsx
@@ -139,7 +139,6 @@ const tokenSyncWorker = new BackgroundTokenSyncer({
       placement: 'bottomRight',
       duration: null,
       btn: (
-        // @ts-ignore
         <Button
           type='primary'
           onClick={() =>

--- a/packages/client/src/main.ce.tsx
+++ b/packages/client/src/main.ce.tsx
@@ -32,17 +32,16 @@ const client = createGraphqlClient({
 });
 
 class Main extends React.Component {
-
   render() {
     return (
       <BrowserRouter>
         <Route path={`${appPrefix}g/`}>
           <ApolloProvider client={client}>
             <MainPage sidebarItems={listCE}>
-            {/* Jupyterhub */}
-            <Route path={`${appPrefix}g/:groupName/hub`} exact>
-              <Jupyterhub />
-            </Route>
+              {/* Jupyterhub */}
+              <Route path={`${appPrefix}g/:groupName/hub`} exact>
+                <Jupyterhub />
+              </Route>
 
               {/* Shared Files */}
               <Route path={`${appPrefix}g/:groupName/browse/:phfsPrefix*`}>
@@ -142,7 +141,6 @@ const tokenSyncWorker = new BackgroundTokenSyncer({
       placement: 'bottomRight',
       duration: null,
       btn: (
-        // @ts-ignore
         <Button
           type='primary'
           onClick={() =>


### PR DESCRIPTION
## Screenshots

![Screenshot 2021-11-11 at 08-56-35 PrimeHub](https://user-images.githubusercontent.com/10325111/141217840-df54d508-95ee-428e-9e64-1f79923c124f.png)
<img width="1426" alt="截圖 2021-11-11 上午8 56 53" src="https://user-images.githubusercontent.com/10325111/141217846-9715b64d-2d1e-483a-81bf-d24831eefbb1.png">
<img width="1428" alt="截圖 2021-11-11 上午8 57 01" src="https://user-images.githubusercontent.com/10325111/141217849-adc7f308-8cbe-4836-88bf-fbea702f2b35.png">

## Descriptions

- Added CTA buttons for each tab
- Removed `@ts-ignore` from the button components

## Testing Image

- `sc22235-4522a160`

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed