### PR TITLE
feat(timezone): added the timezone query

### DIFF
--- a/packages/graphql-server/src/graphql/index.graphql
+++ b/packages/graphql-server/src/graphql/index.graphql
@@ -1,4 +1,5 @@
 # import System, SystemUpdateInput from "./system.graphql"
+# import Timezone from "./timezone.graphql"
 # import User, UsersOrderBy, UserMultiEmailResponse, UserConnection, UserWhereInput, UserWhereUniqueInput, UserCreateInput, UserUpdateInput, UserActionResponse from "./user.graphql"
 # import Group, GroupOrderByInput, GroupConnection, GroupWhereInput, GroupWhereUniqueInput, GroupCreateInput, GroupUpdateInput from "./group.graphql"
 # import InstanceType, InstanceTypeOrderByInput, InstanceTypeConnection, InstanceTypeWhereInput, InstanceTypeWhereUniqueInput, InstanceTypeCreateInput, InstanceTypeUpdateInput from "./instanceType.graphql"
@@ -17,6 +18,7 @@ scalar JSON
 type Query {
   """System"""
   system: System!
+  timezone: Timezone!
 
   """User"""
   me: User

--- a/packages/graphql-server/src/graphql/system.graphql
+++ b/packages/graphql-server/src/graphql/system.graphql
@@ -1,14 +1,10 @@
 # import CannerImage, CannerImageInput from "common.graphql"
 # import License from "../ee/graphql/license.graphql"
+# import Timezzone from "./timezone.graphql"
 
 type Org {
   name: String
   logo: CannerImage
-}
-
-type Timezone {
-  name: String!
-  offset: Float!
 }
 
 type Smtp {

--- a/packages/graphql-server/src/graphql/system.graphql
+++ b/packages/graphql-server/src/graphql/system.graphql
@@ -1,6 +1,6 @@
 # import CannerImage, CannerImageInput from "common.graphql"
 # import License from "../ee/graphql/license.graphql"
-# import Timezzone from "./timezone.graphql"
+# import Timezone from "./timezone.graphql"
 
 type Org {
   name: String

--- a/packages/graphql-server/src/graphql/timezone.graphql
+++ b/packages/graphql-server/src/graphql/timezone.graphql
@@ -1,0 +1,4 @@
+type Timezone {
+  name: String!
+  offset: Float!
+}

--- a/packages/graphql-server/src/middlewares/auth.ts
+++ b/packages/graphql-server/src/middlewares/auth.ts
@@ -3,6 +3,7 @@ import { isAdmin, isClient, isUser, isGroupAdmin } from '../utils/roles';
 export const ShieldQuery = {
   '*': isAdmin,
   'system': or(isAdmin, isClient),
+  'timezone': or(isAdmin, isClient, isUser),
   'me': or(isAdmin, isUser),
   'user': or(isAdmin, isClient),
   'group': or(isAdmin, isGroupAdmin, isClient),

--- a/packages/graphql-server/src/resolvers/constant.ts
+++ b/packages/graphql-server/src/resolvers/constant.ts
@@ -17,7 +17,7 @@ const findTimezone = () => {
     offset: 0,
   };
 };
-const DEFAULT_TIMEZONE = findTimezone();
+export const DEFAULT_TIMEZONE = findTimezone();
 
 export const createDefaultSystemSettings = (defaultUserVolumeCapacity: string) => ({
   org: {

--- a/packages/graphql-server/src/resolvers/index.ts
+++ b/packages/graphql-server/src/resolvers/index.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import * as system from './system';
+import * as timezone from './timezone';
 import * as user from './user';
 import * as group from './group';
 import { crd as instanceType} from './instanceType';
@@ -22,6 +23,7 @@ import { makeExecutableSchema } from 'graphql-tools';
 export const resolvers = {
   Query: {
     system: system.query,
+    timezone: timezone.query,
     me: user.me,
     user: user.queryOne,
     users: user.query,

--- a/packages/graphql-server/src/resolvers/timezone.ts
+++ b/packages/graphql-server/src/resolvers/timezone.ts
@@ -1,0 +1,24 @@
+import KcAdminClient from 'keycloak-admin';
+import { mapValues, get } from 'lodash';
+import { unflatten } from 'flat';
+import { DEFAULT_TIMEZONE } from './constant';
+import { Context } from './interface';
+import { findTimezone } from '../utils/timezones';
+
+export const query = async (root, args, context: Context) => {
+  const everyoneGroupId = context.everyoneGroupId;
+  const kcAdminClient: KcAdminClient = context.kcAdminClient;
+  const { attributes } = await kcAdminClient.groups.findOne({
+    id: everyoneGroupId,
+  });
+
+  const fetchedData = unflatten(
+    mapValues(attributes, value => {
+      return (value && value[0]) || null;
+    })
+  );
+  const timezone =
+    findTimezone(get(fetchedData, 'timezone')) || DEFAULT_TIMEZONE;
+
+  return timezone;
+};


### PR DESCRIPTION
## Description

- Added the system `timezone` query

**Query**

```graphql
query {
  timezone {
    name
    offset
  }
}
```

**Response**

```json
{
  "data": {
    "timezone": {
      "name": "Asia/Tokyo",
      "offset": 9
    }
  }
}
```

## Image

- sc23197-6a93390a

Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed