### PR TITLE
Cascading deletion for group related resources

### DIFF
--- a/packages/client/src/admin/Group/GroupList.tsx
+++ b/packages/client/src/admin/Group/GroupList.tsx
@@ -11,20 +11,26 @@ import { reduce, get } from 'lodash';
 import PageTitle from 'components/pageTitle';
 import PageBody from 'components/pageBody';
 import Breadcrumbs from 'components/share/breadcrumb';
-import { GroupsConnection, DeleteGroup } from 'queries/Group.graphql';
+import {
+  GroupsConnection,
+  GroupResourcesToBeDeleted,
+  DeleteGroup,
+} from 'queries/Group.graphql';
 import queryString from 'querystring';
-import { graphql } from 'react-apollo';
+import { graphql, withApollo } from 'react-apollo';
 import { compose } from 'recompose';
 import InfuseButton from 'components/infuseButton';
 import { FilterRow, FilterPlugins, ButtonCol } from 'components/share';
 import { errorHandler } from 'utils/errorHandler';
 import { TruncateTableField } from 'utils/TruncateTableField';
+import ApolloClient from 'apollo-client';
 
 const { confirm } = Modal;
 const { Search } = Input;
 const ButtonGroup = Button.Group;
 
 type Props = {
+  client: ApolloClient<any>;
   dataSource: any;
   loading?: boolean;
   listGroup?: any;
@@ -71,28 +77,58 @@ export function GroupList(props: Props) {
   const edit = id => {
     history.push(`group/${id}`);
   };
-  const remove = (id, record) => {
+  const remove = async (id, record, client) => {
     const { deleteGroup } = props;
-    const { name } = record;
-    confirm({
-      title: `Delete Group`,
-      content: (
-        <span>
-          Do you really want to delete group: "<b>{name}</b>"?
-        </span>
-      ),
-      iconType: 'info-circle',
-      okText: 'Yes',
-      okType: 'danger',
-      cancelText: 'No',
-      maskClosable: true,
-      onOk() {
-        return deleteGroup({ variables: { where: { id } } });
-      },
-    });
+    const variables = { where: { id } };
+    try {
+      const result = await client.query({
+        query: GroupResourcesToBeDeleted,
+        fetchPolicy: 'no-cache',
+        variables,
+      });
+
+      const resources = result.data?.groupResourcesToBeDeleted;
+      const resourceCount = Object.values(resources)
+        .filter(value => typeof value === 'number')
+        .reduce((prev, curr) => prev + curr, 0);
+      const messageForDeleted =
+        resourceCount > 0 ? (
+          <>
+            You'll permenently lose your:
+            <ul style={{ marginBottom: 0 }}>
+              {resources.jobs ? <li>{resources.jobs} Jobs</li> : <></>}
+              {resources.schedules ? <li>{resources.schedules} Schedules</li> : <></>}
+              {resources.apps ? <li>{resources.apps} Apps</li> : <></>}
+              {resources.deployments ? <li>{resources.deployments} Deployemnts</li> : <></>}
+            </ul>
+          </>
+        ) : (
+          <></>
+        );
+
+      confirm({
+        title: `Do you really want to delete this group?`,
+        content: (
+          <span>
+            All resources associated to this group will be deleted. {messageForDeleted}
+          </span>
+        ),
+        iconType: 'info-circle',
+        okText: 'Yes',
+        okType: 'danger',
+        cancelText: 'No',
+        maskClosable: true,
+        onOk() {
+          return deleteGroup({ variables });
+        },
+      });
+    } catch (err) {
+      errorHandler(err);
+    }
   };
 
   const renderAction = (id, record) => {
+    const { client } = props;
     return (
       <ButtonGroup>
         <Tooltip placement='bottom' title='Edit'>
@@ -107,7 +143,7 @@ export function GroupList(props: Props) {
             icon='delete'
             data-testid='delete-button'
             disabled={DISABLE_GROUP === true}
-            onClick={() => remove(id, record)}
+            onClick={() => remove(id, record, client)}
           />
         </Tooltip>
       </ButtonGroup>
@@ -293,6 +329,7 @@ export function GroupList(props: Props) {
 
 export default compose(
   withRouter,
+  withApollo,
   graphql(GroupsConnection, {
     options: (props: RouteComponentProps) => {
       try {
@@ -333,12 +370,13 @@ export default compose(
     alias: 'withDeleteGroup',
   })
 )(props => {
-  const { listGroup, deleteGroup } = props;
+  const { listGroup, deleteGroup, client } = props;
   const { group, loading } = listGroup;
   const dataSource = group ? group.edges.map(edge => edge.node) : [];
   return (
     <React.Fragment>
       <GroupList
+        client={client}
         dataSource={dataSource}
         listGroup={listGroup}
         deleteGroup={deleteGroup}

--- a/packages/client/src/admin/Group/GroupList.tsx
+++ b/packages/client/src/admin/Group/GroupList.tsx
@@ -91,20 +91,17 @@ export function GroupList(props: Props) {
       const resourceCount = Object.values(resources)
         .filter(value => typeof value === 'number')
         .reduce((prev, curr) => prev + curr, 0);
-      const messageForDeleted =
-        resourceCount > 0 ? (
-          <>
-            You'll permenently lose your:
-            <ul style={{ marginBottom: 0 }}>
-              {resources.jobs ? <li>{resources.jobs} Jobs</li> : <></>}
-              {resources.schedules ? <li>{resources.schedules} Recurring Jobs</li> : <></>}
-              {resources.apps ? <li>{resources.apps} Apps</li> : <></>}
-              {resources.deployments ? <li>{resources.deployments} Deployemnts</li> : <></>}
-            </ul>
-          </>
-        ) : (
-          <></>
-        );
+      const messageForDeleted = resourceCount > 0 && (
+        <>
+          You'll permanently lose your:
+          <ul style={{ marginBottom: 0 }}>
+            {resources.jobs ? <li>{resources.jobs} Jobs</li> : <></>}
+            {resources.schedules ? <li>{resources.schedules} Recurring Jobs</li> : <></>}
+            {resources.apps ? <li>{resources.apps} Apps</li> : <></>}
+            {resources.deployments ? <li>{resources.deployments} Deployemnts</li> : <></>}
+          </ul>
+        </>
+      );
 
       confirm({
         title: `Do you really want to delete this group?`,

--- a/packages/client/src/admin/Group/GroupList.tsx
+++ b/packages/client/src/admin/Group/GroupList.tsx
@@ -97,7 +97,7 @@ export function GroupList(props: Props) {
             You'll permenently lose your:
             <ul style={{ marginBottom: 0 }}>
               {resources.jobs ? <li>{resources.jobs} Jobs</li> : <></>}
-              {resources.schedules ? <li>{resources.schedules} Schedules</li> : <></>}
+              {resources.schedules ? <li>{resources.schedules} Recurring Jobs</li> : <></>}
               {resources.apps ? <li>{resources.apps} Apps</li> : <></>}
               {resources.deployments ? <li>{resources.deployments} Deployemnts</li> : <></>}
             </ul>

--- a/packages/client/src/queries/Group.graphql
+++ b/packages/client/src/queries/Group.graphql
@@ -37,6 +37,15 @@ query GroupsConnection($page: Int, $orderBy: GroupOrderByInput, $where: GroupWhe
   }
 }
 
+query GroupResourcesToBeDeleted($where: GroupWhereUniqueInput!) {
+  groupResourcesToBeDeleted(where: $where) {
+    apps
+    jobs
+    schedules
+    deployments
+  }
+}
+
 mutation DeleteGroup($where: GroupWhereUniqueInput!) {
   deleteGroup(where: $where) {
     id

--- a/packages/graphql-server/src/app.ts
+++ b/packages/graphql-server/src/app.ts
@@ -58,7 +58,7 @@ import { mountTusCtrl } from './controllers/tusCtrl';
 import { mountStoreCtrl } from './controllers/storeCtrl';
 import { Telemetry } from './utils/telemetry';
 import { createDefaultTraitMiddleware } from './utils/telemetryTraits';
-import { schema } from './resolvers';
+import { registerGroupDeletionCallbacks, schema } from './resolvers';
 import { Client as MinioClient } from 'minio';
 
 export class App {
@@ -234,6 +234,9 @@ export class App {
       }
     });
     observer.observe();
+
+    // Group deletion callbacks
+    registerGroupDeletionCallbacks();
   }
 
   /**

--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -12,6 +12,7 @@ import { createEETraitMiddleware } from './utils/telemetryTraits';
 import { App as AppCE } from '../app';
 import { mountUsageCtrl, } from './controllers/usageCtrl';
 import { applyMiddleware } from 'graphql-middleware';
+import { registerGroupDeletionCallbacks } from './resolvers';
 
 export class AppEE extends AppCE {
   persistLog: PersistLog;
@@ -50,6 +51,9 @@ export class AppEE extends AppCE {
 
     // phJob
     this.phJobCacheList = new PhJobCacheList(config.k8sCrdNamespace);
+
+    // Group deletion callbacks
+    registerGroupDeletionCallbacks();
   }
 
   /**

--- a/packages/graphql-server/src/ee/app.ts
+++ b/packages/graphql-server/src/ee/app.ts
@@ -1,6 +1,6 @@
 import Koa from 'koa';
 import Router from 'koa-router';
-import { schema } from './resolvers';
+import { schema, registerGroupDeletionCallbacks } from './resolvers';
 import { permissions as authMiddleware } from './middlewares/auth';
 import { JobLogCtrl } from './controllers/jobLogCtrl';
 import { PhJobCacheList } from './crdClient/phJobCacheList';
@@ -12,7 +12,6 @@ import { createEETraitMiddleware } from './utils/telemetryTraits';
 import { App as AppCE } from '../app';
 import { mountUsageCtrl, } from './controllers/usageCtrl';
 import { applyMiddleware } from 'graphql-middleware';
-import { registerGroupDeletionCallbacks } from './resolvers';
 
 export class AppEE extends AppCE {
   persistLog: PersistLog;

--- a/packages/graphql-server/src/ee/resolvers/index.ts
+++ b/packages/graphql-server/src/ee/resolvers/index.ts
@@ -13,6 +13,7 @@ import { makeExecutableSchema, mergeSchemas } from 'graphql-tools';
 import { gql } from 'apollo-server';
 import { importSchema } from 'graphql-import';
 import { resolvers as ceResolvers } from '../../resolvers';
+import { registerGroupDeletionCallback } from '../../resolvers/group';
 
 const eeResolvers = {
   Query: {
@@ -95,3 +96,9 @@ export const schema: any = mergeSchemas({
     eeSchema,
   ],
 });
+
+export const registerGroupDeletionCallbacks = () => {
+  registerGroupDeletionCallback('jobs', async () => 0);
+  registerGroupDeletionCallback('schedules', async () => 0);
+  registerGroupDeletionCallback('deployments', async () => 0);
+};

--- a/packages/graphql-server/src/ee/resolvers/index.ts
+++ b/packages/graphql-server/src/ee/resolvers/index.ts
@@ -98,7 +98,7 @@ export const schema: any = mergeSchemas({
 });
 
 export const registerGroupDeletionCallbacks = () => {
-  registerGroupDeletionCallback('jobs', async () => 0);
+  registerGroupDeletionCallback('jobs', phJob.destroyByGroup);
   registerGroupDeletionCallback('schedules', phSchedule.destroyByGroup);
-  registerGroupDeletionCallback('deployments', async () => 0);
+  registerGroupDeletionCallback('deployments', phDeployment.destroyByGroup);
 };

--- a/packages/graphql-server/src/ee/resolvers/index.ts
+++ b/packages/graphql-server/src/ee/resolvers/index.ts
@@ -99,6 +99,6 @@ export const schema: any = mergeSchemas({
 
 export const registerGroupDeletionCallbacks = () => {
   registerGroupDeletionCallback('jobs', async () => 0);
-  registerGroupDeletionCallback('schedules', async () => 0);
+  registerGroupDeletionCallback('schedules', phSchedule.destroyByGroup);
   registerGroupDeletionCallback('deployments', async () => 0);
 };

--- a/packages/graphql-server/src/ee/resolvers/phDeployment.ts
+++ b/packages/graphql-server/src/ee/resolvers/phDeployment.ts
@@ -533,6 +533,55 @@ export const destroy = async (root, args, context: Context) => {
   return {id};
 };
 
+export const destroyByGroup = async (
+  context: Context,
+  group: { id: string; name: string },
+  dryrun: boolean
+) => {
+  const { crdClient } = context;
+  const phDeployments = await crdClient.phDeployments.list();
+  const transformedPhDeployments = phDeployments.map(item => ({
+    id: item.metadata.name,
+    groupId: item.spec.groupId,
+    groupName: item.spec.groupName || '',
+  }));
+
+  let counter = 0;
+  for (const deployment of transformedPhDeployments) {
+    if (
+      deployment.groupId !== group.id &&
+      deployment.groupName !== group.name
+    ) {
+      continue;
+    }
+
+    if (!dryrun) {
+      const payload = {
+        component: logger.components.phDeployment,
+        userId: context.userId,
+        username: context.username,
+        id: deployment.id,
+      };
+      try {
+        await context.crdClient.phDeployments.del(deployment.id);
+        logger.info({
+          ...payload,
+          type: 'DELETE',
+        });
+      } catch (err) {
+        logger.error({
+          ...payload,
+          type: 'DELETE_FAILED',
+          message: err.message,
+          stack: err.stack,
+        });
+      }
+    }
+    counter++;
+  }
+  return counter;
+};
+
 export const available = async (root, args, context: Context) => {
   const {crdClient} = context;
   const where = args && args.where;

--- a/packages/graphql-server/src/ee/resolvers/phDeployment.ts
+++ b/packages/graphql-server/src/ee/resolvers/phDeployment.ts
@@ -543,7 +543,7 @@ export const destroyByGroup = async (
   const transformedPhDeployments = phDeployments.map(item => ({
     id: item.metadata.name,
     groupId: item.spec.groupId,
-    groupName: item.spec.groupName || '',
+    groupName: item.spec.groupName,
   }));
 
   let counter = 0;

--- a/packages/graphql-server/src/ee/resolvers/phJob.ts
+++ b/packages/graphql-server/src/ee/resolvers/phJob.ts
@@ -459,7 +459,7 @@ export const destroyByGroup = async (
   const transformedPhJobs = phJobs.map(item => ({
     id: item.metadata.name,
     groupId: item.spec.groupId,
-    groupName: item.spec.groupName || '',
+    groupName: item.spec.groupName,
   }));
 
   let counter = 0;

--- a/packages/graphql-server/src/ee/resolvers/phJob.ts
+++ b/packages/graphql-server/src/ee/resolvers/phJob.ts
@@ -448,3 +448,49 @@ export const notifyJobEvent = async (root, args, context: Context) => {
   }
   return 0;
 };
+
+export const destroyByGroup = async (
+  context: Context,
+  group: { id: string; name: string },
+  dryrun: boolean
+) => {
+  const { crdClient } = context;
+  const phJobs = await crdClient.phJobs.list();
+  const transformedPhJobs = phJobs.map(item => ({
+    id: item.metadata.name,
+    groupId: item.spec.groupId,
+    groupName: item.spec.groupName || '',
+  }));
+
+  let counter = 0;
+  for (const job of transformedPhJobs) {
+    if (job.groupId !== group.id && job.groupName !== group.name) {
+      continue;
+    }
+
+    if (!dryrun) {
+      const payload = {
+        component: logger.components.phJob,
+        userId: context.userId,
+        username: context.username,
+        id: job.id,
+      };
+      try {
+        await context.crdClient.phJobs.del(job.id);
+        logger.info({
+          ...payload,
+          type: 'DELETE',
+        });
+      } catch (err) {
+        logger.error({
+          ...payload,
+          type: 'DELETE_FAILED',
+          message: err.message,
+          stack: err.stack,
+        });
+      }
+    }
+    counter++;
+  }
+  return counter;
+};

--- a/packages/graphql-server/src/ee/resolvers/phSchedule.ts
+++ b/packages/graphql-server/src/ee/resolvers/phSchedule.ts
@@ -55,7 +55,9 @@ export interface PhScheduleMutationInput {
 }
 
 // tslint:disable-next-line:max-line-length
-export const transform = async (item: Item<PhScheduleSpec, PhScheduleStatus>, namespace: string, graphqlHost: string, kcAdminClient: KeycloakAdminClient): Promise<PhSchedule> => {
+export const transform = async (
+  item: Item<PhScheduleSpec, PhScheduleStatus>
+): Promise<PhSchedule> => {
   const jobTemplate = item.spec.jobTemplate;
   return {
     id: item.metadata.name,
@@ -226,7 +228,7 @@ const listQuery = async (client: CustomResource<PhScheduleSpec>, where: any = {}
   const {namespace, graphqlHost, userId: currentUserId, kcAdminClient} = context;
   if (where && where.id) {
     const phSchedule = await client.get(where.id);
-    const transformed = await transform(phSchedule, namespace, graphqlHost, kcAdminClient);
+    const transformed = await transform(phSchedule);
     const viewable = await canUserViewSchedule(currentUserId, transformed, context);
     if (!viewable) {
       throw new ApolloError('user not auth', NOT_AUTH_ERROR);
@@ -236,7 +238,7 @@ const listQuery = async (client: CustomResource<PhScheduleSpec>, where: any = {}
 
   const phSchedules = await client.list();
   const transformedPhSchedules = await Promise.all(
-    phSchedules.map(schedule => transform(schedule, namespace, graphqlHost, kcAdminClient)));
+    phSchedules.map(schedule => transform(schedule)));
 
   if (where && where.mine) {
     where.userId_eq = currentUserId;
@@ -269,7 +271,7 @@ export const queryOne = async (root, args, context: Context) => {
   const {crdClient, userId: currentUserId} = context;
   const phSchedule = await crdClient.phSchedules.get(id);
   const transformed =
-    await transform(phSchedule, context.namespace, context.graphqlHost, context.kcAdminClient);
+    await transform(phSchedule);
   const viewable = await canUserViewSchedule(currentUserId, transformed, context);
   if (!viewable) {
     throw new ApolloError('user not auth', NOT_AUTH_ERROR);
@@ -286,7 +288,7 @@ export const create = async (root, args, context: Context) => {
     throw new ApolloError('user not auth', NOT_AUTH_ERROR);
   }
   const phSchedule = await createSchedule(context, data);
-  return transform(phSchedule, context.namespace, context.graphqlHost, context.kcAdminClient);
+  return transform(phSchedule);
 };
 
 export const update = async (root, args, context: Context) => {
@@ -338,7 +340,7 @@ export const update = async (root, args, context: Context) => {
     }
   };
   const updatedSchedule = await context.crdClient.phSchedules.patch(args.where.id, {metadata, spec});
-  return transform(updatedSchedule, context.namespace, context.graphqlHost, context.kcAdminClient);
+  return transform(updatedSchedule);
 };
 
 export const run = async (root, args, context: Context) => {
@@ -382,5 +384,45 @@ export const destroy = async (root, args, context: Context) => {
   }
 
   await context.crdClient.phSchedules.del(id);
+  logger.info({
+    component: logger.components.phSchedule,
+    type: 'DELETE',
+    userId: context.userId,
+    username: context.username,
+    id: phSchedule.metadata.name,
+  });
+
   return {id};
+};
+
+export const destroyByGroup = async (
+  context: Context,
+  group: { id: string; name: string },
+  dryrun: boolean
+) => {
+  const { crdClient } = context;
+  const phSchedules = await crdClient.phSchedules.list();
+  const transformedPhSchedules = await Promise.all(
+    phSchedules.map(schedule => transform(schedule))
+  );
+  let counter = 0;
+
+  for (const schedule of transformedPhSchedules) {
+    if (schedule.groupId !== group.id && schedule.groupName !== group.name) {
+      continue;
+    }
+
+    if (!dryrun) {
+      await context.crdClient.phSchedules.del(schedule.id);
+      logger.info({
+        component: logger.components.phSchedule,
+        type: 'DELETE',
+        userId: context.userId,
+        username: context.username,
+        id: schedule.id,
+      });
+    }
+    counter++;
+  }
+  return counter;
 };

--- a/packages/graphql-server/src/graphql/group.graphql
+++ b/packages/graphql-server/src/graphql/group.graphql
@@ -55,6 +55,16 @@ type Group {
   mlflow: MLflowSetting
 }
 
+type GroupResourcesToBeDeleted {
+  # CE
+  apps: Int
+
+  # EE
+  jobs: Int
+  schedules: Int
+  deployments: Int
+}
+
 """order"""
 input GroupOrderByInput {
   name: String

--- a/packages/graphql-server/src/graphql/index.graphql
+++ b/packages/graphql-server/src/graphql/index.graphql
@@ -62,6 +62,7 @@ type Query {
     first: Int
     last: Int
   ): GroupConnection!
+  groupResourcesToBeDeleted(where: GroupWhereUniqueInput!): GroupResourcesToBeDeleted
 
   """InstanceType"""
   instanceType(where: InstanceTypeWhereUniqueInput!): InstanceType

--- a/packages/graphql-server/src/logger.ts
+++ b/packages/graphql-server/src/logger.ts
@@ -23,6 +23,7 @@ export enum components {
   secret = 'Secret',
   buildImage = 'BuildImage',
   phJob = 'PhJob',
+  phSchedule = 'PhSchedule',
   phDeployment = 'PhDeployment',
   phApplication = 'PhApplication',
   internal = 'Internal',

--- a/packages/graphql-server/src/resolvers/group.ts
+++ b/packages/graphql-server/src/resolvers/group.ts
@@ -428,7 +428,7 @@ export const groupResourcesToBeDeleted = async (
   });
 
   const transformedGroup = transform(group);
-  return await deleteAllGroupResources(context, transformedGroup, true);
+  return deleteAllGroupResources(context, transformedGroup, true);
 };
 
 /**

--- a/packages/graphql-server/src/resolvers/index.ts
+++ b/packages/graphql-server/src/resolvers/index.ts
@@ -18,6 +18,7 @@ import * as GraphQLJSON from 'graphql-type-json';
 import { gql } from 'apollo-server';
 import { importSchema } from 'graphql-import';
 import { makeExecutableSchema } from 'graphql-tools';
+import { registerGroupDeletionCallback } from './group';
 
 // A map of functions which return data for the schema.
 export const resolvers = {
@@ -31,6 +32,7 @@ export const resolvers = {
     group: group.queryOne,
     groups: group.query,
     groupsConnection: group.connectionQuery,
+    groupResourcesToBeDeleted: group.groupResourcesToBeDeleted,
     secret: secret.queryOne,
     secrets: secret.query,
     secretsConnection: secret.connectionQuery,
@@ -102,3 +104,7 @@ export const schema: any = makeExecutableSchema({
   typeDefs: gql(importSchema(path.resolve(__dirname, '../graphql/index.graphql'))),
   resolvers,
 });
+
+export const registerGroupDeletionCallbacks = () => {
+  registerGroupDeletionCallback('apps', async () => 0);
+};

--- a/packages/graphql-server/src/resolvers/index.ts
+++ b/packages/graphql-server/src/resolvers/index.ts
@@ -106,5 +106,5 @@ export const schema: any = makeExecutableSchema({
 });
 
 export const registerGroupDeletionCallbacks = () => {
-  registerGroupDeletionCallback('apps', async () => 0);
+  registerGroupDeletionCallback('apps', phApplication.destroyByGroup);
 };

--- a/packages/graphql-server/src/resolvers/index.ts
+++ b/packages/graphql-server/src/resolvers/index.ts
@@ -18,7 +18,6 @@ import * as GraphQLJSON from 'graphql-type-json';
 import { gql } from 'apollo-server';
 import { importSchema } from 'graphql-import';
 import { makeExecutableSchema } from 'graphql-tools';
-import { registerGroupDeletionCallback } from './group';
 
 // A map of functions which return data for the schema.
 export const resolvers = {
@@ -106,5 +105,5 @@ export const schema: any = makeExecutableSchema({
 });
 
 export const registerGroupDeletionCallbacks = () => {
-  registerGroupDeletionCallback('apps', phApplication.destroyByGroup);
+  group.registerGroupDeletionCallback('apps', phApplication.destroyByGroup);
 };

--- a/packages/graphql-server/src/resolvers/phApplication.ts
+++ b/packages/graphql-server/src/resolvers/phApplication.ts
@@ -356,7 +356,7 @@ export const destroy = async (root, args, context: Context) => {
     type: 'DELETE',
     userId: context.userId,
     username: context.username,
-    id: id,
+    id,
   });
 
   // reset the mlflow setting if the current setting is linked to deleted app.

--- a/packages/graphql-server/src/resolvers/phApplication.ts
+++ b/packages/graphql-server/src/resolvers/phApplication.ts
@@ -374,7 +374,7 @@ export const destroyByGroup = async (
   const phApplications = await crdClient.phApplications.list();
   const transformedPhApplications = phApplications.map(item => ({
     id: item.metadata.name,
-    groupName: item.spec.groupName || '',
+    groupName: item.spec.groupName,
   }));
 
   let counter = 0;


### PR DESCRIPTION
# Introduction
When deleting a group, the corresponding resource should be deleted as well.

# Changes
1. Add group deletion hook
2. Add one more graphql resolver to query to resource to be deleted
3. Show the resources to be deleted in UI

# Screen shots
![image](https://user-images.githubusercontent.com/860633/143154759-d944131a-cccf-4d01-8b10-d3474ea81200.png)
![image](https://user-images.githubusercontent.com/860633/143154791-cb2a68c9-3d46-4ba3-bbb7-a5c1667cb345.png)
![image](https://user-images.githubusercontent.com/860633/143154831-39ea4986-ed45-4ee6-b4c6-fafb78fab748.png)

# Test cases
- [x] Check if all resources (apps, jobs, recurring jobs, deployment) are deleted in the groups
- [x] Check the group shared volume is deleted when an app is mounting on it
- [x] Check the primehub-ce case

# Reviewer note
This PR does not include the graphql integration test. Will put in another story/pr.

# Testing Image
- ~~sc21284-9825df2~~
- sc21284-e060f3d