### PR TITLE
Cascading deletion for group related resources - typo and reorder

### DIFF
--- a/packages/client/src/admin/Group/GroupList.tsx
+++ b/packages/client/src/admin/Group/GroupList.tsx
@@ -97,8 +97,8 @@ export function GroupList(props: Props) {
           <ul style={{ marginBottom: 0 }}>
             {resources.jobs ? <li>{resources.jobs} Jobs</li> : <></>}
             {resources.schedules ? <li>{resources.schedules} Recurring Jobs</li> : <></>}
+            {resources.deployments ? <li>{resources.deployments} Deployments</li> : <></>}
             {resources.apps ? <li>{resources.apps} Apps</li> : <></>}
-            {resources.deployments ? <li>{resources.deployments} Deployemnts</li> : <></>}
           </ul>
         </>
       );


### PR DESCRIPTION
Signed-off-by: Eric Yang <ericy@infuseai.io>

- typo of `Deployments`
- reorder these 4 features to align with the order in user portal (job, recurring, deployment, app)