### PR TITLE
fix(shareFile): display all the items and disabled type is a file

### DIFF
--- a/packages/client/src/containers/sharedFiles/SharedFilesPage.tsx
+++ b/packages/client/src/containers/sharedFiles/SharedFilesPage.tsx
@@ -142,15 +142,26 @@ function ShareFilesPage({ form, datasets, ...props }: Props) {
           name: string;
         }>
       )
-        .filter(file => file.name.endsWith('/'))
-        .map(folder => {
-          const folderName = folder.name.replace('/', '');
+        .filter(file => file.name !== '.dataset')
+        .map(file => {
+          if (file.name.endsWith('/')) {
+            const folderName = file.name.replace('/', '');
+
+            return {
+              key: `${eventKey}/${folderName}`,
+              value: `${eventKey}/${folderName}`,
+              title: folderName,
+              icon: <Icon type='folder' />,
+            };
+          }
 
           return {
-            key: `${eventKey}/${folderName}`,
-            value: `${eventKey}/${folderName}`,
-            title: folderName,
-            icon: <Icon type='folder' />,
+            key: `${eventKey}/${file.name}`,
+            value: `${eventKey}/${file.name}`,
+            title: file.name,
+            disabled: true,
+            isLeaf: true,
+            icon: <Icon type='file' />,
           };
         });
 


### PR DESCRIPTION
## Screenshot

![Kapture 2021-12-23 at 10 29 29](https://user-images.githubusercontent.com/10325111/147178804-e85e298f-d5fa-4d3a-9052-8ad15fae625d.gif)

## Problem

- The original implementation made the user confused if a dataset didn't have any subfolders after clicking the folder and fetching data the triangle will disappear.

## Solution

- List all the items in the dataset and disable the type of *file* item

## Image

- `sc23500-a820f96f`

Signed-off-by: Jie Peng <im@jiepeng.me>

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed