### PR TITLE
[Bug] override default value of minio partSize

### DIFF
--- a/packages/graphql-server/src/controllers/storeCtrl.ts
+++ b/packages/graphql-server/src/controllers/storeCtrl.ts
@@ -83,7 +83,8 @@ export const mountStoreCtrl = (router: Router,
     }
 
     try {
-      const result = await minioClient.putObject(storeBucket, objectPath, ctx.req);
+      const chunkSize = 64 * 1024 * 1024;
+      const result = await minioClient.putObject(storeBucket, objectPath, ctx.req, chunkSize);
       ctx.body = {
         success: true,
       };

--- a/packages/graphql-server/src/controllers/storeCtrl.ts
+++ b/packages/graphql-server/src/controllers/storeCtrl.ts
@@ -83,8 +83,7 @@ export const mountStoreCtrl = (router: Router,
     }
 
     try {
-      const chunkSize = 64 * 1024 * 1024;
-      const result = await minioClient.putObject(storeBucket, objectPath, ctx.req, chunkSize);
+      const result = await minioClient.putObject(storeBucket, objectPath, ctx.req);
       ctx.body = {
         success: true,
       };

--- a/packages/graphql-server/src/utils/minioClient.ts
+++ b/packages/graphql-server/src/utils/minioClient.ts
@@ -19,7 +19,8 @@ export const createMinioClient = (endpoint: string, accessKey: string, secretKey
         port,
         useSSL,
         accessKey,
-        secretKey
+        secretKey,
+        partSize: 5 * 1024 * 1024   // override partSize (5MB is min size defined by Minio)
     });
     return minioClient;
 };


### PR DESCRIPTION
Signed-off-by: wcchang <wcchang@infuseai.io>
Co-authored-by: popcorny <celu@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug fix

**What this PR does / why we need it**:
the original minio `partSize` (64MB) would cause OOM, we change the default `partSize` to reduce memory usage. 

**Which issue(s) this PR fixes**:
sc-23977

## Image
- ~~`sc23977-ad548569`~~
- `sc23977-1b16babb`