### PR TITLE
fix(sharefile): apply encodeURIComponent to filename

### DIFF
--- a/packages/client/src/components/Browser/Browser.tsx
+++ b/packages/client/src/components/Browser/Browser.tsx
@@ -187,7 +187,11 @@ function ShareFileActions({
   );
   const DownloadFile = (
     <Menu.Item key='download'>
-      <a href={`${appPrefix}files/${prefix}${props.name}?download=1`}>
+      <a
+        href={`${appPrefix}files/${prefix}${encodeURIComponent(
+          props.name
+        )}?download=1`}
+      >
         Download file
       </a>
     </Menu.Item>

--- a/packages/client/src/components/Browser/Uploader.tsx
+++ b/packages/client/src/components/Browser/Uploader.tsx
@@ -6,7 +6,7 @@ import { compose } from 'recompose';
 import { Upload, Icon } from 'antd';
 import { errorHandler } from 'utils/errorHandler';
 import axios, { Canceler } from 'axios';
-import { toGroupPath } from 'utils/';
+import { toGroupPath } from 'utils/index';
 
 const { Dragger } = Upload;
 
@@ -70,7 +70,10 @@ function _Uploader(props: Props) {
       phfsPrefix,
       file.name
     );
-    const endpoint = graphqlEndpoint.replace('/graphql', `/files/${filePath}`);
+    const endpoint = graphqlEndpoint.replace(
+      '/graphql',
+      `/files/${encodeURIComponent(filePath)}`
+    );
     const headers = {
       authorization: `Bearer ${getAccessToken()}`,
     };


### PR DESCRIPTION
## Screenshots

| Before | After |
| ------ | ----- |
|<img width="1080" alt="截圖 2022-01-05 上午8 46 00" src="https://user-images.githubusercontent.com/10325111/148144748-3e3d8856-7126-4810-8069-fe43cec54600.png">|<img width="1080" alt="截圖 2022-01-05 上午8 19 07" src="https://user-images.githubusercontent.com/10325111/148144754-df769869-268c-447a-843e-7a1e442d1c9f.png">|


https://user-images.githubusercontent.com/10325111/148144886-8ec82f23-bb20-481d-8ad2-3d30327d2010.mp4

## Description

- applied `encodeURIComponent` to file name when upload file & download file


Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed